### PR TITLE
[Eddy] Step 5: ViewController 연결 & 화면 전환

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		BC545A4D27BB74C10053E2BD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC545A4C27BB74C10053E2BD /* Assets.xcassets */; };
 		BC545A5027BB74C10053E2BD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BC545A4E27BB74C10053E2BD /* LaunchScreen.storyboard */; };
 		BC545A5827BB76FA0053E2BD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = BC545A5727BB76FA0053E2BD /* README.md */; };
+		BC9AB2A927BCE643009B4E01 /* GrayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9AB2A827BCE643009B4E01 /* GrayViewController.swift */; };
+		BC9AB2AB27BD0E7E009B4E01 /* YellowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9AB2AA27BD0E7D009B4E01 /* YellowViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +28,8 @@
 		BC545A4F27BB74C10053E2BD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BC545A5127BB74C10053E2BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BC545A5727BB76FA0053E2BD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
+		BC9AB2A827BCE643009B4E01 /* GrayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrayViewController.swift; sourceTree = "<group>"; };
+		BC9AB2AA27BD0E7D009B4E01 /* YellowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YellowViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +65,8 @@
 				BC545A4327BB74BF0053E2BD /* AppDelegate.swift */,
 				BC545A4527BB74BF0053E2BD /* SceneDelegate.swift */,
 				BC545A4727BB74BF0053E2BD /* ViewController.swift */,
+				BC9AB2AA27BD0E7D009B4E01 /* YellowViewController.swift */,
+				BC9AB2A827BCE643009B4E01 /* GrayViewController.swift */,
 				BC545A5727BB76FA0053E2BD /* README.md */,
 				BC545A4927BB74BF0053E2BD /* Main.storyboard */,
 				BC545A4C27BB74C10053E2BD /* Assets.xcassets */,
@@ -142,9 +148,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC9AB2A927BCE643009B4E01 /* GrayViewController.swift in Sources */,
 				BC545A4827BB74BF0053E2BD /* ViewController.swift in Sources */,
 				BC545A4427BB74BF0053E2BD /* AppDelegate.swift in Sources */,
 				BC545A4627BB74BF0053E2BD /* SceneDelegate.swift in Sources */,
+				BC9AB2AB27BD0E7E009B4E01 /* YellowViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -78,10 +78,10 @@
             </objects>
             <point key="canvasLocation" x="1701" y="-224"/>
         </scene>
-        <!--Yellow View Controller-->
+        <!--Gray View Controller-->
         <scene sceneID="kV4-75-hdC">
             <objects>
-                <viewController id="58e-fP-YbN" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="58e-fP-YbN" customClass="GrayViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jmE-ef-GHD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -104,6 +104,15 @@
                                     <segue destination="ONR-YV-MPt" kind="unwind" unwindAction="unwindToFirstViewControllerWithSegue:" id="a66-IT-Jfw"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
+                                <rect key="frame" x="183" y="476" width="49" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="58e-fP-YbN" eventType="touchUpInside" id="VhQ-jj-8Ly"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="pKk-mO-GVn"/>
                         <color key="backgroundColor" systemColor="systemGray2Color"/>
@@ -115,10 +124,10 @@
             </objects>
             <point key="canvasLocation" x="2462.3188405797105" y="-224.33035714285714"/>
         </scene>
-        <!--View Controller-->
+        <!--Yellow View Controller-->
         <scene sceneID="2u5-T5-Lfe">
             <objects>
-                <viewController id="drC-Aa-I9w" sceneMemberID="viewController">
+                <viewController id="drC-Aa-I9w" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="g29-VI-3d8">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -78,10 +78,10 @@
             </objects>
             <point key="canvasLocation" x="1701" y="-224"/>
         </scene>
-        <!--View Controller-->
+        <!--Yellow View Controller-->
         <scene sceneID="kV4-75-hdC">
             <objects>
-                <viewController id="58e-fP-YbN" sceneMemberID="viewController">
+                <viewController id="58e-fP-YbN" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jmE-ef-GHD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -86,29 +86,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muL-vb-W4b">
-                                <rect key="frame" x="174" y="400" width="67" height="42"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muL-vb-W4b">
+                                <rect key="frame" x="170.5" y="405.5" width="73" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="다음"/>
+                                <buttonConfiguration key="configuration" style="plain" title="다음 👉"/>
                                 <connections>
                                     <segue destination="drC-Aa-I9w" kind="show" id="N7P-qC-25P"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1hT-iQ-J4s">
-                                <rect key="frame" x="174" y="342" width="67" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1hT-iQ-J4s">
+                                <rect key="frame" x="170.5" y="366.5" width="73" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="이전"/>
+                                <buttonConfiguration key="configuration" style="plain" title="이전 👈"/>
                                 <connections>
                                     <segue destination="ONR-YV-MPt" kind="unwind" unwindAction="unwindToFirstViewControllerWithSegue:" id="a66-IT-Jfw"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
-                                <rect key="frame" x="174" y="476" width="67" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
+                                <rect key="frame" x="170.5" y="444.5" width="73" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기 ❌"/>
                                 <connections>
                                     <action selector="closeButtonTouched:" destination="58e-fP-YbN" eventType="touchUpInside" id="VhQ-jj-8Ly"/>
                                 </connections>
@@ -116,6 +113,14 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="pKk-mO-GVn"/>
                         <color key="backgroundColor" systemColor="systemGray2Color"/>
+                        <constraints>
+                            <constraint firstItem="muL-vb-W4b" firstAttribute="top" secondItem="1hT-iQ-J4s" secondAttribute="bottom" constant="8" id="2Xz-R2-Ocn"/>
+                            <constraint firstItem="1vd-Ga-4gc" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="bi5-5d-Dnt"/>
+                            <constraint firstItem="muL-vb-W4b" firstAttribute="centerY" secondItem="jmE-ef-GHD" secondAttribute="centerY" id="mda-4G-Lba"/>
+                            <constraint firstItem="1vd-Ga-4gc" firstAttribute="top" secondItem="muL-vb-W4b" secondAttribute="bottom" constant="8" id="skH-LC-IRI"/>
+                            <constraint firstItem="1hT-iQ-J4s" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="uzk-sM-2c1"/>
+                            <constraint firstItem="muL-vb-W4b" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="xy1-4J-9Ik"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="hUC-NH-8Jr"/>
                 </viewController>
@@ -132,15 +137,21 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kcM-tn-44O">
-                                <rect key="frame" x="174" y="332" width="67" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kcM-tn-44O">
+                                <rect key="frame" x="170.5" y="405.5" width="73" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="이전"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기 ❌"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="drC-Aa-I9w" eventType="touchUpInside" id="Z4j-VU-npX"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="P9N-8S-EG8"/>
                         <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                        <constraints>
+                            <constraint firstItem="kcM-tn-44O" firstAttribute="centerY" secondItem="g29-VI-3d8" secondAttribute="centerY" id="3Kg-Mm-re5"/>
+                            <constraint firstItem="kcM-tn-44O" firstAttribute="centerX" secondItem="g29-VI-3d8" secondAttribute="centerX" id="9tB-AX-Hj3"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="M7G-u9-zqW"/>
                 </viewController>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -86,40 +86,46 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muL-vb-W4b">
-                                <rect key="frame" x="170.5" y="405.5" width="73" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="다음 👉"/>
-                                <connections>
-                                    <segue destination="drC-Aa-I9w" kind="show" id="N7P-qC-25P"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1hT-iQ-J4s">
-                                <rect key="frame" x="170.5" y="366.5" width="73" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="이전 👈"/>
-                                <connections>
-                                    <segue destination="ONR-YV-MPt" kind="unwind" unwindAction="unwindToFirstViewControllerWithSegue:" id="a66-IT-Jfw"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
-                                <rect key="frame" x="170.5" y="444.5" width="73" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기 ❌"/>
-                                <connections>
-                                    <action selector="closeButtonTouched:" destination="58e-fP-YbN" eventType="touchUpInside" id="VhQ-jj-8Ly"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="RX7-7V-562">
+                                <rect key="frame" x="137.5" y="347" width="139.5" height="148"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1hT-iQ-J4s">
+                                        <rect key="frame" x="0.0" y="0.0" width="139.5" height="31"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Unwind 👈"/>
+                                        <connections>
+                                            <segue destination="ONR-YV-MPt" kind="unwind" unwindAction="unwindToFirstViewControllerWithSegue:" id="a66-IT-Jfw"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muL-vb-W4b">
+                                        <rect key="frame" x="0.0" y="39" width="139.5" height="31"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Show (Segue) 👉"/>
+                                        <connections>
+                                            <segue destination="drC-Aa-I9w" kind="show" id="N7P-qC-25P"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="glX-85-Hjs">
+                                        <rect key="frame" x="0.0" y="78" width="139.5" height="31"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Button (Code) 👉"/>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
+                                        <rect key="frame" x="0.0" y="117" width="139.5" height="31"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Dismiss ❌"/>
+                                        <connections>
+                                            <action selector="closeButtonTouched:" destination="58e-fP-YbN" eventType="touchUpInside" id="VhQ-jj-8Ly"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="pKk-mO-GVn"/>
                         <color key="backgroundColor" systemColor="systemGray2Color"/>
                         <constraints>
-                            <constraint firstItem="muL-vb-W4b" firstAttribute="top" secondItem="1hT-iQ-J4s" secondAttribute="bottom" constant="8" id="2Xz-R2-Ocn"/>
-                            <constraint firstItem="1vd-Ga-4gc" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="bi5-5d-Dnt"/>
-                            <constraint firstItem="muL-vb-W4b" firstAttribute="centerY" secondItem="jmE-ef-GHD" secondAttribute="centerY" id="mda-4G-Lba"/>
-                            <constraint firstItem="1vd-Ga-4gc" firstAttribute="top" secondItem="muL-vb-W4b" secondAttribute="bottom" constant="8" id="skH-LC-IRI"/>
-                            <constraint firstItem="1hT-iQ-J4s" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="uzk-sM-2c1"/>
-                            <constraint firstItem="muL-vb-W4b" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="xy1-4J-9Ik"/>
+                            <constraint firstItem="RX7-7V-562" firstAttribute="centerX" secondItem="jmE-ef-GHD" secondAttribute="centerX" id="IU2-Qd-RIo"/>
+                            <constraint firstItem="RX7-7V-562" firstAttribute="centerY" secondItem="jmE-ef-GHD" secondAttribute="centerY" id="dAu-9p-R71"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="hUC-NH-8Jr"/>
@@ -138,12 +144,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kcM-tn-44O">
-                                <rect key="frame" x="170.5" y="405.5" width="73" height="31"/>
+                                <rect key="frame" x="158" y="405.5" width="98" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기 ❌"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Dismiss ❌"/>
                                 <connections>
                                     <action selector="closeButtonTouched:" destination="drC-Aa-I9w" eventType="touchUpInside" id="Z4j-VU-npX"/>
                                 </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3fg-dQ-Tfi">
+                                <rect key="frame" x="145.5" y="366.5" width="123" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Dismiss (Code)"/>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="P9N-8S-EG8"/>
@@ -151,6 +162,8 @@
                         <constraints>
                             <constraint firstItem="kcM-tn-44O" firstAttribute="centerY" secondItem="g29-VI-3d8" secondAttribute="centerY" id="3Kg-Mm-re5"/>
                             <constraint firstItem="kcM-tn-44O" firstAttribute="centerX" secondItem="g29-VI-3d8" secondAttribute="centerX" id="9tB-AX-Hj3"/>
+                            <constraint firstItem="3fg-dQ-Tfi" firstAttribute="centerX" secondItem="g29-VI-3d8" secondAttribute="centerX" id="PIx-Nn-XOo"/>
+                            <constraint firstItem="kcM-tn-44O" firstAttribute="top" secondItem="3fg-dQ-Tfi" secondAttribute="bottom" constant="8" id="mcS-zc-g75"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="M7G-u9-zqW"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -87,10 +87,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="RX7-7V-562">
-                                <rect key="frame" x="137.5" y="347" width="139.5" height="148"/>
+                                <rect key="frame" x="138" y="347" width="138.5" height="148"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1hT-iQ-J4s">
-                                        <rect key="frame" x="0.0" y="0.0" width="139.5" height="31"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="138.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Unwind 👈"/>
                                         <connections>
@@ -98,7 +98,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muL-vb-W4b">
-                                        <rect key="frame" x="0.0" y="39" width="139.5" height="31"/>
+                                        <rect key="frame" x="0.0" y="39" width="138.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Show (Segue) 👉"/>
                                         <connections>
@@ -106,12 +106,15 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="glX-85-Hjs">
-                                        <rect key="frame" x="0.0" y="78" width="139.5" height="31"/>
+                                        <rect key="frame" x="0.0" y="78" width="138.5" height="31"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Button (Code) 👉"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Show (Code) 👉"/>
+                                        <connections>
+                                            <action selector="showButtonTouched:" destination="58e-fP-YbN" eventType="touchUpInside" id="MvT-yZ-cPa"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
-                                        <rect key="frame" x="0.0" y="117" width="139.5" height="31"/>
+                                        <rect key="frame" x="0.0" y="117" width="138.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Dismiss ❌"/>
                                         <connections>
@@ -138,7 +141,7 @@
         <!--Yellow View Controller-->
         <scene sceneID="2u5-T5-Lfe">
             <objects>
-                <viewController id="drC-Aa-I9w" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="YellowViewController" id="drC-Aa-I9w" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="g29-VI-3d8">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -105,7 +105,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vd-Ga-4gc">
-                                <rect key="frame" x="183" y="476" width="49" height="31"/>
+                                <rect key="frame" x="174" y="476" width="67" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="닫기"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -147,17 +147,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kcM-tn-44O">
-                                <rect key="frame" x="158" y="405.5" width="98" height="31"/>
+                                <rect key="frame" x="158" y="406" width="98" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Dismiss ❌"/>
                                 <connections>
                                     <action selector="closeButtonTouched:" destination="drC-Aa-I9w" eventType="touchUpInside" id="Z4j-VU-npX"/>
                                 </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3fg-dQ-Tfi">
-                                <rect key="frame" x="145.5" y="366.5" width="123" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Dismiss (Code)"/>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="P9N-8S-EG8"/>
@@ -165,8 +160,6 @@
                         <constraints>
                             <constraint firstItem="kcM-tn-44O" firstAttribute="centerY" secondItem="g29-VI-3d8" secondAttribute="centerY" id="3Kg-Mm-re5"/>
                             <constraint firstItem="kcM-tn-44O" firstAttribute="centerX" secondItem="g29-VI-3d8" secondAttribute="centerX" id="9tB-AX-Hj3"/>
-                            <constraint firstItem="3fg-dQ-Tfi" firstAttribute="centerX" secondItem="g29-VI-3d8" secondAttribute="centerX" id="PIx-Nn-XOo"/>
-                            <constraint firstItem="kcM-tn-44O" firstAttribute="top" secondItem="3fg-dQ-Tfi" secondAttribute="bottom" constant="8" id="mcS-zc-g75"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="M7G-u9-zqW"/>

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -8,14 +8,20 @@
 import UIKit
 
 class GrayViewController: UIViewController {
-
+    @IBAction func showButtonTouched(_ sender: UIButton) {
+        let storyBoard : UIStoryboard = UIStoryboard(name: "Main", bundle:nil)
+        let yellowViewController = storyBoard.instantiateViewController(withIdentifier: "YellowViewController")
+        show(yellowViewController, sender: self)
+    }
+    
+    
     @IBAction func closeButtonTouched(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // Do any additional setup after loading the view.
     }
     
@@ -39,15 +45,15 @@ class GrayViewController: UIViewController {
         print(#file, #line, #function, #column)
     }
     
-
+    
     /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
+     // MARK: - Navigation
+     
+     // In a storyboard-based application, you will often want to do a little preparation before navigation
+     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+     // Get the new view controller using segue.destination.
+     // Pass the selected object to the new view controller.
+     }
+     */
+    
 }

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -1,0 +1,29 @@
+//
+//  YellowViewController.swift
+//  PhotoFrame
+//
+//  Created by Bumgeun Song on 2022/02/16.
+//
+
+import UIKit
+
+class GrayViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -19,6 +19,26 @@ class GrayViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        print("Gray View will appear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("Gray View did appear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        print("Gray View will disappear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        print("Gray View did disappear")
+        print(#file, #line, #function, #column)
+    }
+    
 
     /*
     // MARK: - Navigation

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -10,7 +10,9 @@ import UIKit
 class GrayViewController: UIViewController {
 
     @IBAction func closeButtonTouched(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
     }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -18,6 +18,25 @@ class YellowViewController: UIViewController {
         
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        print("Yellow View will appear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("Yellow View did appear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        print("Yellow View will disappear")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        print("Yellow View did disappear")
+        print(#file, #line, #function, #column)
+    }
 
     /*
     // MARK: - Navigation

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -15,7 +15,6 @@ class YellowViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -7,10 +7,8 @@
 
 import UIKit
 
-class GrayViewController: UIViewController {
+class YellowViewController: UIViewController {
 
-    @IBAction func closeButtonTouched(_ sender: UIButton) {
-    }
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -9,10 +9,13 @@ import UIKit
 
 class YellowViewController: UIViewController {
 
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
     }
     
 


### PR DESCRIPTION
**작업 목록**
- [x] `GrayViewController`와 `YellowViewController`를 추가하고 Storyboard와 연결 
- [x] `Gray`, `Yellow`에 각각 Close Button을 구현
- [x] ViewController의 Lifecycle 마다 print를 찍어서 각 함수 호출 시점 확인
- [x] 코드를 사용해 `YellowViewController`를 보여주는 Action 추가

**학습 키워드**
- 'View Controller'를 보여주고 없애는 [3가지 방법](https://developer.apple.com/documentation/uikit/view_controllers/showing_and_hiding_view_controllers) (Storyboard Segue, Container View Controller, ViewController 직접 조작)
- ViewController Lifecycle: 다른 view controller가 위에 올라가도, 뒤에 있는 View Controller는 사라지지 않음.
- [show(_:sender:)](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621377-show), [dismiss(animated:completion:)](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621505-dismiss)
- `instantiateViewController` 호출시 identifier를 storyboard의 vc에 string으로 지정해줘야 함.

**고민과 해결**
- `instantiateViewController`를 써야하는 자리에, 간단하게 `YellowViewController()`클래스를 생성해도 Yellow 화면으로 넘어갈 수 있지 않을까? 하고 `show(YellowViewController(), sender: self)` 를 사용해보았습니다. 
![screenshot3 001](https://user-images.githubusercontent.com/17468015/154266361-f0ef8085-60d7-48a7-b692-a6e560b7a9e8.png)

- 오른쪽 화면처럼, 이전 ViewController가 백그라운드로 이동하는 변화는 있는데, 새로운 ViewController의 화면은 렌더링되지 않았습니다. (흥미로운 건 화면만 없을 뿐 콘솔에는 ViewWillApear, ViewDidAppear가 제대로 찍혔다는 점입니다)
- 궁금해져서 검색을 열심히 해보았으나 어떤 키워드로 할지 몰라서인지 명확한 답을 찾진 못했습니다. 
- YellowViewController는 단순히 Storyboard와 연결되어 Storyboard를 조작할 뿐이고, 실제 보여지는 View는 Storyboard에 있는 것이기 때문에 반드시 Storyboard를 사용해서 `instantiateViewController`를 해줘야 하는걸까요?
