### PR TITLE
[Jed] Step 1-6 : Container ViewController 활용하기

### DIFF
--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -11,6 +11,7 @@
         <!--Item 2-->
         <scene sceneID="uUh-ez-hpy">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kv8-VM-p02" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewController id="03h-xc-dDA" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="M5l-0n-UZk">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
@@ -20,11 +21,10 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="Item 2" id="33t-Eb-cI4"/>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="kv8-VM-p02" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1000" y="-957"/>
         </scene>
-        <!--Item 1-->
+        <!--View Controller-->
         <scene sceneID="jtg-dv-1PM">
             <objects>
                 <viewController storyboardIdentifier="ViewController" id="DvB-Gi-ecE" customClass="ViewController" customModule="PhotoFrame" sceneMemberID="viewController">
@@ -49,13 +49,16 @@
                                     <action selector="nextButtonTouchedDown:" destination="DvB-Gi-ecE" eventType="touchDown" id="0Uy-AX-bVu"/>
                                     <action selector="nextButtonTouchedUpInside:" destination="DvB-Gi-ecE" eventType="touchUpInside" id="jVQ-6O-TQM"/>
                                     <action selector="nextButtonTouchedUpOutside:" destination="DvB-Gi-ecE" eventType="touchUpOutside" id="Gfn-UI-h7Z"/>
+                                    <segue destination="ZPo-c5-w6j" kind="show" id="eWA-nc-aKw"/>
                                 </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="kKw-VU-FyD"/>
                         <color key="backgroundColor" systemColor="systemTealColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item 1" id="mMy-L3-dIh" colorLabel="IBBuiltInLabel-Yellow"/>
+                    <navigationItem key="navigationItem" id="Apo-eR-kNd">
+                        <barButtonItem key="leftBarButtonItem" title="Item" id="TA1-JZ-XoO"/>
+                    </navigationItem>
                     <connections>
                         <outlet property="firstLabel" destination="JAf-rj-kdh" id="yBb-FN-Llg"/>
                         <outlet property="nextButton" destination="NAv-Tj-maS" id="fnb-P9-VUc"/>
@@ -63,7 +66,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h13-He-z3B" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1000.0000000000001" y="-1612.5"/>
+            <point key="canvasLocation" x="-89.855072463768124" y="-1612.5"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="exm-V1-Wd3">
@@ -75,7 +78,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="DvB-Gi-ecE" kind="relationship" relationship="viewControllers" id="wNi-WI-doD"/>
+                        <segue destination="Ymf-mg-LkS" kind="relationship" relationship="viewControllers" id="wNi-WI-doD"/>
                         <segue destination="03h-xc-dDA" kind="relationship" relationship="viewControllers" id="xWc-mO-d2y"/>
                     </connections>
                 </tabBarController>
@@ -86,6 +89,8 @@
         <!--Gray View Controller-->
         <scene sceneID="Id6-gq-3dU">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fCe-Cr-bkk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="zla-q3-DDF" userLabel="Exit" sceneMemberID="exit"/>
                 <viewController storyboardIdentifier="GrayViewController" id="ZPo-c5-w6j" customClass="GrayViewController" customModule="PhotoFrame" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wrS-Hg-RDc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
@@ -98,11 +103,11 @@
                                 <state key="normal" title="다음"/>
                                 <connections>
                                     <action selector="nextButton:" destination="zla-q3-DDF" eventType="touchUpInside" id="BWW-hk-Q20"/>
-                                    <segue destination="fve-yE-h0D" kind="presentation" modalPresentationStyle="fullScreen" id="npY-hR-okB"/>
+                                    <segue destination="fve-yE-h0D" kind="show" id="npY-hR-okB"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NpX-J4-oFr">
-                                <rect key="frame" x="135" y="170" width="153" height="89"/>
+                                <rect key="frame" x="130.5" y="0.0" width="153" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="닫기"/>
@@ -120,10 +125,8 @@
                         <outlet property="nextButton" destination="DHj-15-Ayh" id="Tt0-Gy-lQe"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="fCe-Cr-bkk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <exit id="zla-q3-DDF" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="-168.11594202898553" y="-1613.1696428571429"/>
+            <point key="canvasLocation" x="742.02898550724649" y="-1613.1696428571429"/>
         </scene>
         <!--Yellow View Controller-->
         <scene sceneID="ios-kl-Wqn">
@@ -170,7 +173,30 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Jpo-GJ-Ln9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <exit id="LNl-f0-Te2" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="728.98550724637687" y="-1613.1696428571429"/>
+            <point key="canvasLocation" x="1639.1304347826087" y="-1613.1696428571429"/>
+        </scene>
+        <!--Item 1-->
+        <scene sceneID="Gl5-xX-ZzI">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" toolbarHidden="NO" id="Ymf-mg-LkS" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item 1" id="mMy-L3-dIh" colorLabel="IBBuiltInLabel-Yellow"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="e8C-9a-hr3">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="pr8-Gk-F6f">
+                        <rect key="frame" x="0.0" y="764" width="414" height="49"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
+                    <connections>
+                        <segue destination="DvB-Gi-ecE" kind="relationship" relationship="rootViewController" id="fSu-NK-98s"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="trj-e4-Lgk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1000.0000000000001" y="-1612.5"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -56,9 +56,7 @@
                         <viewLayoutGuide key="safeArea" id="kKw-VU-FyD"/>
                         <color key="backgroundColor" systemColor="systemTealColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="Apo-eR-kNd">
-                        <barButtonItem key="leftBarButtonItem" title="Item" id="TA1-JZ-XoO"/>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="Apo-eR-kNd"/>
                     <connections>
                         <outlet property="firstLabel" destination="JAf-rj-kdh" id="yBb-FN-Llg"/>
                         <outlet property="nextButton" destination="NAv-Tj-maS" id="fnb-P9-VUc"/>

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -6,7 +6,7 @@ class GrayViewController: UIViewController {
     @IBOutlet weak var nextButton: UIButton!
     
     @IBAction func exitButtonTouched(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        self.navigationController?.popViewController(animated: true)
     }
     
     @IBAction func unwind(_ segue: UIStoryboardSegue){

--- a/PhotoFrame/PhotoFrame/GrayViewController.swift
+++ b/PhotoFrame/PhotoFrame/GrayViewController.swift
@@ -20,18 +20,22 @@ class GrayViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
         print(#file, #line, #function, #column)
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(true)
         print(#file, #line, #function, #column)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
         print(#file, #line, #function, #column)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(true)
         print(#file, #line, #function, #column)
     }
     

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -10,14 +10,12 @@ class ViewController: UIViewController {
         self.firstLabel.backgroundColor = UIColor.yellow
         self.firstLabel.alpha = 0.5
         print(#function)
-        
-        guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: "GrayViewController")else{
-            print("No NextViewController Found")
-            return
+
+        if let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: "GrayViewController"){
+            nextViewController.modalPresentationStyle = .fullScreen
+            nextViewController.modalTransitionStyle = .coverVertical
+            self.present(nextViewController, animated: true, completion: nil)
         }
-        nextViewController.modalPresentationStyle = .fullScreen
-        nextViewController.modalTransitionStyle = .coverVertical
-        self.present(nextViewController, animated: true, completion: nil)
     }
 
     @IBAction func nextButtonTouchedUpOutside(_ sender: Any) {
@@ -36,7 +34,6 @@ class ViewController: UIViewController {
         
         setFirstLabel()
         setNextButton()
-        
     }
     
     func setNextButton(){

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -10,12 +10,6 @@ class ViewController: UIViewController {
         self.firstLabel.backgroundColor = UIColor.yellow
         self.firstLabel.alpha = 0.5
         print(#function)
-
-        if let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: "GrayViewController"){
-            nextViewController.modalPresentationStyle = .fullScreen
-            nextViewController.modalTransitionStyle = .coverVertical
-            self.present(nextViewController, animated: true, completion: nil)
-        }
     }
 
     @IBAction func nextButtonTouchedUpOutside(_ sender: Any) {
@@ -53,7 +47,7 @@ class ViewController: UIViewController {
         firstLabel.backgroundColor = UIColor.lightGray
         firstLabel.center.x = self.view.center.x
         firstLabel.center.y = self.view.center.y
-        
+    
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -241,3 +241,7 @@ override func viewDidDisappear(_ animated: Bool) {
 
 ​    
 
+### 1-6. Container View Controller 활용하기
+
+
+

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ override func viewDidDisappear(_ animated: Bool) {
 
 #### 6-1. Navigation Controller
 
-- 공식문서에서는 UINavigationController에 대해 스택 기반의 계층화된 콘텐츠가 모여있는 view controller 컨테이너로 정의하고 있음
+- [공식문서](https://developer.apple.com/documentation/uikit/uinavigationcontroller)에서는 UINavigationController에 대해 스택 기반의 계층화된 콘텐츠가 모여있는 view controller 컨테이너로 정의하고 있음
+
+  *A container view controller that defines a stack-based scheme for navigating hierarchical content.*
+
 - 이러한 구조에서는 한 시점에 하나의 view controller만이 보이도록 하고 있으며, 하나의 view controller이 보이도록 선택하면 이를 스크린에 push하고(기존의 화면은 화면에서 사라짐),  back button과 같은 닫기 버튼을 누르면 top에 위치한 view controller을 화면에서 pop하여 사라지게 한 후 바로 밑에 있는 view controller이 화면에 위치하도록 함
+
   - 이런 식으로 여러 view가 스택과 같이 push, pop의 과정을 거치며 사용자에게 보이는 화면은 스택의 top에 해당하는 부분이라는 점에서, 화면을 전환하고 닫는 관련 함수의 이름도 popViewController, pushViewController와 같은 형식으로 표현

--- a/README.md
+++ b/README.md
@@ -241,7 +241,38 @@ override func viewDidDisappear(_ animated: Bool) {
 
 ​    
 
-### 1-6. Container View Controller 활용하기
+### 6. Container View Controller 활용하기
 
+<img src="https://user-images.githubusercontent.com/68586291/154426264-1886c131-be91-426d-b684-6616e664a222.gif" alt="image" style="align:center; width: 30%;"/>
 
+- Navigation Bar을 추가
 
+- 처음에는 연결된 GrayViewController, YelloViewController Scene에 Back 네비게이션 버튼이 자동으로 생기지 않는 문제가 발생했음
+
+- 또한 화면 넘김 역시 기존과 그대로 아래에서 위로 모달이 올라오는 방식으로 이루어졌음
+
+- 우선 화면을 연결하는 Segue를 다시 생성하고, 화면을 넘기는 방식(kind)을 모달이 아닌 show로 바꿈으로써 연결된 화면들에 자동으로 네비게이션 버튼이 생기고 왼쪽에서 오른쪽으로 화면이 넘기는 애니메이션 확인
+
+- 이후 기존에 아래와 같이 작성한 화면을 닫는 코드는 동작하지 않았음
+
+  ```swift
+  @IBAction func dismissButtonTouched(_ sender: Any) {
+    self.dismiss(animated: true, completion: nil)
+  }
+  ```
+
+- 위의 코드는 아래와 같이 navigationController 프로퍼티의 함수를 호출하는 식으로 변경하여 이전 화면으로 돌아가는 것을 확인
+
+  ```swift
+  @IBAction func exitButtonTouched(_ sender: UIButton) {
+    self.navigationController?.popViewController(animated: true)
+  }
+  ```
+
+​    
+
+#### 6-1. Navigation Controller
+
+- 공식문서에서는 UINavigationController에 대해 스택 기반의 계층화된 콘텐츠가 모여있는 view controller 컨테이너로 정의하고 있음
+- 이러한 구조에서는 한 시점에 하나의 view controller만이 보이도록 하고 있으며, 하나의 view controller이 보이도록 선택하면 이를 스크린에 push하고(기존의 화면은 화면에서 사라짐),  back button과 같은 닫기 버튼을 누르면 top에 위치한 view controller을 화면에서 pop하여 사라지게 한 후 바로 밑에 있는 view controller이 화면에 위치하도록 함
+  - 이런 식으로 여러 view가 스택과 같이 push, pop의 과정을 거치며 사용자에게 보이는 화면은 스택의 top에 해당하는 부분이라는 점에서, 화면을 전환하고 닫는 관련 함수의 이름도 popViewController, pushViewController와 같은 형식으로 표현


### PR DESCRIPTION
## 작업 내용
- [x] 스토리보드에서 Navigation Controller 추가(Embed In)
- [x] 연결된 각 화면마다 우측에서 좌측으로 넘어가는 애니메이션이 나타나면서 전환되는 것 확인
- [x] Back 네비게이션 버튼 생성 및 동작 확인
- [x] 뷰 컨트롤러의 콜백 함수의 동작 확인
- [x] UINavigationController의 구조 학습
    
## 학습 키워드
- Navigation Controller
- UINavigationController
- navigation stack
    
## 고민과 해결 
### 1. guard let, if let의 차이 및 사용 기준 고민
- 기존에는 아래와 같이 guard let을 통해 스토리보드에 연결된 View Controller이 있는 지 확인하고, 없는 경우에는 else 구문을 먼저 실행해서 함수를 return처리하고자 했습니다.
```swift
guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: "GrayViewController")else{
  print("No NextViewController Found")
  return
}
nextViewController.modalPresentationStyle = .fullScreen
nextViewController.modalTransitionStyle = .coverVertical
self.present(nextViewController, animated: true, completion: nil
```
- 하지만 위의 코드를 담은 함수는 단순히 View Controller이 존재하는 지(nil 여부)만 확인해서 다음 화면으로 넘기고, 그렇지 않은 경우에는 부가적인 처리가 사실상 필요없는 함수였습니다.
- 따라서 굳이 else 구문에 return을 명시할 필요 없이 if let으로 변경해서 View Controller이 존재하는 경우의 처리만 명시하면 될 것이라 판단해서 코드를 간단히 수정했습니다.
```swift
if let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: "GrayViewController"){
    nextViewController.modalPresentationStyle = .fullScreen
    nextViewController.modalTransitionStyle = .coverVertical
    self.present(nextViewController, animated: true, completion: nil
}
```
- guard let의 경우에는 옵셔널이 nil인 경우 단순한 return, continue 등과 같은 제어문의 실행 외에 부가적인 예외 처리가 필요한 경우에 명시하는 것이 더욱 적절할 것이라 생각했습니다.
    
### 2. Navigation Controller 생성 관련
> 편의상 각 Scene을 순서대로 1,2,3이라 칭했습니다.
- 화면 1->2->3 과 같은 식으로 연결된 구조인 상태에서 맨 처음 스토리보드에서 1을 선택한 상태로 Navigatino Controller을 추가했더니 자동으로 네비게이션 바에 Back버튼이 생기지 않을 뿐더러, 화면 전환 동작도 기존처럼 아래에서 위로 모달이 올라오는 방식으로 이루어지고 있었습니다.
- 이전 단계까지 화면 전환 동작을 구현한 방식을 살펴보니 아래와 같았습니다.
    - 1->2의 전환은 Segue없이 다음 버튼에 아래와 같은 함수 호출을 통해 이루어지고 있었습니다.
    ```swift
    self.present(nextViewController, animated: true, completion: nil)
    ```  
    - 스토리보드에서 남아있던 Segue의 화면 전환 방식(kind)를 보니 show가 아닌 present modally로 되어있었습니다.
- 우선 함수 호출을 통한 화면 동작을 없앤 후, 모든 화면을 Segue로 연결한 후 화면 전환을 show로 변경했습니다.
- 이후 정상적으로 오른쪽에서 왼쪽으로 화면이 넘어가는 애니메이션이 나타나는 것을 확인했습니다.  
     
### 3. Back 버튼 및 기타 닫기 버튼 동작 관련
- Navigation Controller 추가 후 기존에 아래와 같이 작성한 화면 닫기 동작이 비활성화된 것을 확인했습니다.
    ```swift
    @IBAction func dismissButtonTouched(_ sender: Any) {
        self.dismiss(animated: true, completion: nil)
    }
    ```
- 루카스를 보니 UINavigationController 기반이기 때문에 아래와 같은 방식으로 화면 닫기가 이루어져야 했습니다.
    ```swift
    @IBAction func exitButtonTouched(_ sender: UIButton) {
        self.navigationController?.popViewController(animated: true)
     }
    ```
-  공식문서를 보니 Navigation Controller은 화면들이 스택 기반으로 push&pop을 반복하면서 사용자에게 화면이 보여지는 것이어서 화면 전환 및 제거도 push & pop 방식으로 이루어지고 있었습니다.
    
## 추후 고민거리
> 질문이라기 보단 아직 고민중인 내용을 정리해봤습니다.
- UINavigationController에 대한 공식 문서를 읽어보면서 navigation stack에 view controller 들을 push&pop 하면서 사용자에게 보여지는 화면을 결정하는 것이라고 하지만 아직까지는 이 부분이 추상적으로 다가왔습니다.
- View Controller 의 계층구조 및 화면들 간 포함관계와, Navigation Controller가 다른 방식과 비교했을 때 어떤 차이가 있는 지 좀 더 구체적으로 학습하려 합니다.