### PR TITLE
[Selina] Step4 - Scene을 Segue로 연결하기

### DIFF
--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -82,14 +82,44 @@
                     <view key="view" contentMode="scaleToFill" id="1zk-pe-4jp">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1J2-Ip-E46">
+                                <rect key="frame" x="171.5" y="405.5" width="71" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Next!!!!"/>
+                                <connections>
+                                    <segue destination="obM-Ks-hqv" kind="show" id="mbK-aY-17Q"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="Zo3-M5-yy8"/>
                         <color key="backgroundColor" red="1" green="0.76244297058229082" blue="0.85208236719575248" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="1J2-Ip-E46" firstAttribute="centerX" secondItem="1zk-pe-4jp" secondAttribute="centerX" id="Or7-Sh-Gi0"/>
+                            <constraint firstItem="1J2-Ip-E46" firstAttribute="centerY" secondItem="1zk-pe-4jp" secondAttribute="centerY" id="eeP-fp-5aa"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="wMT-y3-VLh"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="una-S9-X15" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2035" y="-441"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="4bZ-99-P3c">
+            <objects>
+                <viewController id="obM-Ks-hqv" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XnS-BX-rwm">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="ehu-Ws-01b"/>
+                        <color key="backgroundColor" red="0.55368724609488851" green="1" blue="0.79409593002388745" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Hgm-q2-eSX"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Piu-MM-aB6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2970" y="-441"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="O1h-if-eKl">

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -22,7 +22,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4mG-JT-oQh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1142" y="167"/>
+            <point key="canvasLocation" x="1141" y="234"/>
         </scene>
         <!--Item 1-->
         <scene sceneID="fjb-V9-7yj">
@@ -33,62 +33,35 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="First View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Z0-Ve-xkp">
-                                <rect key="frame" x="113" y="389" width="74.5" height="20.5"/>
+                                <rect key="frame" x="170" y="389" width="74.5" height="20.5"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Loaded by FirstViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gt3-7R-K4c">
-                                <rect key="frame" x="113" y="540" width="229" height="21"/>
+                                <rect key="frame" x="93" y="428" width="229" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p2X-EI-0Sh">
-                                <rect key="frame" x="90" y="294" width="59" height="31"/>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="25" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p2X-EI-0Sh">
+                                <rect key="frame" x="177.5" y="275" width="59" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next!"/>
                                 <connections>
                                     <action selector="nextButtonTouched:" destination="1xY-0E-ssV" eventType="touchUpInside" id="9ny-v5-wNw"/>
-                                    <action selector="secondAction:" destination="1xY-0E-ssV" eventType="touchUpInside" id="wEL-kg-wqH"/>
-                                    <action selector="thirdAction:" destination="1xY-0E-ssV" eventType="touchUpInside" id="ej8-u5-VD1"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qfT-1P-Wzw">
-                                <rect key="frame" x="57" y="675" width="58" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Test1"/>
-                                <connections>
-                                    <action selector="testAction:" destination="1xY-0E-ssV" eventType="touchUpInside" id="Hcn-rx-dM9"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AKJ-xZ-ruc">
-                                <rect key="frame" x="156" y="675" width="60" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Test2"/>
-                                <connections>
-                                    <action selector="testAction:" destination="1xY-0E-ssV" eventType="touchUpInside" id="mLd-Ta-APC"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vue-dN-5Ab">
-                                <rect key="frame" x="279" y="675" width="60" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Test3"/>
-                                <connections>
-                                    <action selector="testAction:" destination="1xY-0E-ssV" eventType="touchUpInside" id="WAA-h8-ghR"/>
                                 </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Usb-5h-oqu"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="p2X-EI-0Sh" firstAttribute="leading" secondItem="Usb-5h-oqu" secondAttribute="leading" constant="90" id="KqG-8J-mSo"/>
-                            <constraint firstItem="p2X-EI-0Sh" firstAttribute="top" secondItem="Usb-5h-oqu" secondAttribute="top" constant="250" id="con-Ew-gX3"/>
+                            <constraint firstItem="p2X-EI-0Sh" firstAttribute="leading" secondItem="Usb-5h-oqu" secondAttribute="leading" constant="177.5" id="5dh-u4-2zY"/>
+                            <constraint firstItem="p2X-EI-0Sh" firstAttribute="top" secondItem="Usb-5h-oqu" secondAttribute="top" constant="231" id="PSo-mE-eha"/>
+                            <constraint firstItem="p2X-EI-0Sh" firstAttribute="centerX" secondItem="E3I-M1-4GG" secondAttribute="centerX" id="iFL-Pv-HD0"/>
+                            <constraint firstItem="Usb-5h-oqu" firstAttribute="trailing" secondItem="p2X-EI-0Sh" secondAttribute="trailing" constant="177.5" id="rMC-sI-AZv"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Item 1" id="t3u-HT-w4F"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -52,6 +52,7 @@
                                 <buttonConfiguration key="configuration" style="plain" title="Next!"/>
                                 <connections>
                                     <action selector="nextButtonTouched:" destination="1xY-0E-ssV" eventType="touchUpInside" id="9ny-v5-wNw"/>
+                                    <segue destination="fWP-MA-5AE" kind="show" id="Tco-Y1-Vzu"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -73,6 +74,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vKv-cq-WsG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1142" y="-441"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="mMR-Nx-J31">
+            <objects>
+                <viewController id="fWP-MA-5AE" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1zk-pe-4jp">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Zo3-M5-yy8"/>
+                        <color key="backgroundColor" red="1" green="0.76244297058229082" blue="0.85208236719575248" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="wMT-y3-VLh"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="una-S9-X15" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2035" y="-441"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="O1h-if-eKl">

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -12,20 +12,6 @@ class ViewController: UIViewController {
     @IBOutlet weak var firstLabel: UILabel!
     @IBOutlet weak var firstDescription: UILabel!
     
-    let firstButton = UIButton(type: UIButton.ButtonType.system) as UIButton
-    let thirdButton = UIButton()
-    
-    @objc func buttonTapped(_ sender: UIButton) {
-        print("\(sender.titleLabel?.text) Button tapped")
-        
-        switch sender {
-        case firstButton:
-            self.firstLabel.text = "첫번째 버튼"
-        default:
-            self.firstLabel.text = "세번째 버튼!"
-        }
-    }
-    
     
     @IBAction func nextButtonTouched(_ sender: UIButton) {
         print("Second Button Tapped")
@@ -35,47 +21,23 @@ class ViewController: UIViewController {
     }
     
     
-    @IBAction func secondAction(_ sender: UIButton) {
-        print("두번째 액션입니다!")
-    }
-    
-    
-    @IBAction func thirdAction(_ sender: UIButton) {
-        print("세번째 액션입니다!")
-    }
-    
-    @IBAction func testAction(_ sender: UIButton) {
-        print("I have multiple buttons")
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        self.firstButton.frame = CGRect(x: self.view.center.x, y: 150, width: 150, height: 45)
-        self.firstButton.backgroundColor = UIColor.systemPink
-        self.firstButton.setTitle("Tap me!", for: UIControl.State.normal)
-        self.firstButton.tintColor = .white
-        self.firstButton.addTarget(self, action: #selector(self.buttonTapped), for: .touchUpInside)
-        
+
         // subView 추가
-        self.view.addSubview(firstButton)
         self.view.addSubview(firstLabel)
         self.view.addSubview(firstDescription)
         
         // Constraints를 코드로 작성하기 위함.
-//        self.firstButton.translatesAutoresizingMaskIntoConstraints = false
         self.firstLabel.translatesAutoresizingMaskIntoConstraints = false
         self.firstDescription.translatesAutoresizingMaskIntoConstraints = false
-        
         
         
         // firstLabel 속성
         self.firstLabel.text = "Selina의 사진액자"
         self.firstLabel.textColor = #colorLiteral(red: 0.8549019694, green: 0.250980407, blue: 0.4784313738, alpha: 1)
-        
         self.firstLabel.backgroundColor = UIColor(red: 250 / 255.0, green: 197 / 255.0, blue: 210 / 255.0, alpha: 1)
         self.firstLabel.backgroundColor = UIColor(cgColor: CGColor(red: 250 / 255.0, green: 197 / 255.0, blue: 210 / 255.0, alpha: 1))
-        
         self.firstLabel.font = UIFont.boldSystemFont(ofSize: 40)
         
         // 세로 위치 중 가운데로 배치
@@ -87,23 +49,7 @@ class ViewController: UIViewController {
         // firstDescription 속성
         self.firstDescription.textColor = UIColor.systemGray
         self.firstDescription.font = UIFont.systemFont(ofSize: 15)
-    
         self.firstDescription.topAnchor.constraint(equalTo: firstLabel.topAnchor, constant: 60).isActive = true
         self.firstDescription.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        
-        
-        // ThirdButton
-        self.view.addSubview(thirdButton)
-        thirdButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        thirdButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
-        thirdButton.widthAnchor.constraint(equalToConstant: 275).isActive = true
-        thirdButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        thirdButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor, constant: 150).isActive = true
-        
-        thirdButton.setTitle("세번째 버튼입니당", for: .normal)
-        thirdButton.setTitleColor(.white, for: .normal)
-        thirdButton.backgroundColor = .purple
-        thirdButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
     }
 }

--- a/README.md
+++ b/README.md
@@ -341,3 +341,87 @@ testAction 메소드에 3개의 버튼을 동시에 연결해보았습니다. �
 - IBOutlet vs IBAction
 - obj-c
 
+
+# Step4. Scene을 Segue로 연결하기
+
+## 💻 작업 목록
+- [x] Main 스토리보드에서 First Scene 옆에 ViewController를 드래그해서 새로운 Scene을 추가한다.
+- [x] 앞 단계에서 추가한 [다음]버튼을 선택하고 `Control + 드래그`를 해서 새로 추가한 Scene에 연결한다.
+- [x] 팝업으로 표시되는 Action Segue에서 `Show` 항목을 선택한다.
+- [x] Scene과 Scene 사이에 화살표를 선택하면 Segue 속성을 변경할 수 있다.
+- [x] 새로 추가한 Scene 속성에서 배경 색상(Background Color)을 원하는 색상으로 변경한다. 새로 앱을 실행해보고 [다음] 버튼을 누르면 새로운 화면이 나타나는지 확인한다.
+- [x] 다시 스토리보드에서 위에 추가한 Scene (혹은 ViewController)에 [다음] 버튼을 추가한다. 우측 옆에 한 단계 더 표현하기 위한 ViewController를 추가하고 배경 색상을 다른 색상으로 변경한다. 위와 마찬가지로 [다음]버튼에서 새 Scene으로 Segue를 연결한다.
+  - [x] 예를 들어 First Scene 다음에 추가한 화면이 Yellow 화면이었다면, First Scene에서 [다음] 버튼을 누르면 Yellow 화면이 표시되고, Yellow 화면에서 [다음] 버튼을 누르면 Blue 화면이 나오는 방식으로 두 단계 표시한다.
+
+## 📱 실행 화면
+
+![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/95578975/154428641-3af1b989-99d7-4e87-a03a-d2316c14c2de.gif)
+
+## ✏️ 추가 학습 거리
+
+### Action Segue 종류
+
+Show, Show Detail은 동일하다. 다만 Show Detail은 UISplitViewController에서 다르게 적용된다.
+
+#### Show
+
+이 segue는 타겟 뷰 컨트롤러의 [showViewController:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621377-showviewcontroller) 메소드를 이용하여 새 콘텐츠를 표시한다. 대부분의 뷰 컨트롤러의 경우, 이 segue가 소스 뷰 컨트롤러를 통해 새 콘텐츠를 modally하게 보여준다. 일부 뷰 컨트롤러는 메소드를 오버라이드하여 다른 동작을 구현하는 데 상요한다. 예를 들어, 네비게이션 컨트롤러는 새로운 뷰 컨트롤러를 navigation stack에 push 한다.
+
+UIKit은 [targetViewControllerForAction:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621415-targetviewcontroller) 메소드를 사용하여 소스 뷰 컨트롤러를 위치시킨다.
+
+#### Show Detail
+
+이 segue는 타겟 뷰 컨트롤러의 [showViewController:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621377-showviewcontroller) 메소드를 이용하여 새 콘텐츠를 표시한다. 이 segue는 UISplitViewController 객체에 내장된 뷰 컨트롤러에만 적용된다. 이 segue를 사용하면 분할 뷰 컨트롤러가 두번째 하위 뷰 컨트롤러 (디테일 뷰 컨트롤러)를 새 콘텐츠로 교체한다. 대부분의 다른 뷰 컨트롤러는 새 컨텐츠를 modally하게 표시한다.
+
+[Example 1](https://stackoverflow.com/questions/26287247/what-are-the-differences-between-segues-show-show-detail-present-modally): In Mail on iPad in landscape, tapping an email in the sidebar replaces the view controller on the right to show the new email.
+
+[Example 2](https://stackoverflow.com/questions/25966215/whats-the-difference-between-all-the-selection-segues): In Messages, tapping a conversation will show the conversation details - replacing the view controller on the right when in a two column layout, or push the conversation when in a single column layout
+
+#### Present Modally
+
+이 segue는 지정된 표시 및 변환 스타일을 사용하여 뷰 컨트롤러를 modally하게 표시한다. 적절한 presentation context를 정의하는 뷰 컨트롤러가 실제 presentation을 처리한다.
+
+#### Present As Popover
+
+수평으로 규칙적인 환경에서 뷰 컨트롤러는 popover로 나타난다. 수평으로 compact한 환경에서 뷰 컨트롤러는 full-screen modal presentation을 사용하여 표시한다.
+
+#### Custom
+
+Interface Builder는 뷰 컨트롤러를 표시하는 것부터 popover로 화면을 컨트롤러에 표시하는 것까지 하나의 뷰 컨트롤러에서 다른 뷰 컨트롤러로 전환하는 모든 표준 방법에 대한 segue를 제공한다. 그러나 내가 원하는 segue가 없을 경우, custom segue를 만들 수 있다.
+
+##### Implementing a Custom Segue
+
+Custom segue를 구현하려면, `UIStoryboardSegue` 를 subclass하고, 아래 메소드들을 구현하면 된다.
+
+- `initWithIdentifier:source:destination:` 메소드를 오버라이드해서 custom segue 객체를 초기화하는데 사용한다. 항상 super를 먼저 호출한다.
+
+- `perform` 메소드를 구현하여 전환 애니메이션을 구성하는데 사용한다.
+
+![image](https://user-images.githubusercontent.com/95578975/154425681-c3d9a646-62b6-4716-938a-d9a74394bb1e.png)
+
+
+
+실행화면은 모두 같았습니다. 
+
+![ezgif com-gif-maker](https://user-images.githubusercontent.com/95578975/154419697-58b6459b-2da6-4e79-b713-84ff619b9f83.gif)
+
+
+
+그래서 이번엔 아이패드로 변경하여 실행해보았습니다.
+
+그 결과, Show, Show Detail, Present Modally는 모두 아래와 같은 화면이 실행되었습니다.
+
+![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/95578975/154429795-e269ca6e-0691-4aed-bc54-07d9fb63fe2d.gif)
+
+
+
+Present As Popover은 아래와 같은 화면이 나왔습니다.
+
+![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/95578975/154429800-6a19a0e2-8bcc-49d6-a42f-36ec45a85f45.gif)
+
+## 💡 학습 키워드
+
+- [Using Segues](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html)
+
+- [Modality](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/modality/)
+- [Popover](https://developer.apple.com/design/human-interface-guidelines/ios/views/popovers/)


### PR DESCRIPTION
## 💻 작업 목록
- [x] Main 스토리보드에서 First Scene 옆에 ViewController를 드래그해서 새로운 Scene을 추가한다.
- [x] 앞 단계에서 추가한 [다음]버튼을 선택하고 `Control + 드래그`를 해서 새로 추가한 Scene에 연결한다.
- [x] 팝업으로 표시되는 Action Segue에서 `Show` 항목을 선택한다.
- [x] Scene과 Scene 사이에 화살표를 선택하면 Segue 속성을 변경할 수 있다.
- [x] 새로 추가한 Scene 속성에서 배경 색상(Background Color)을 원하는 색상으로 변경한다. 새로 앱을 실행해보고 [다음] 버튼을 누르면 새로운 화면이 나타나는지 확인한다.
- [x] 다시 스토리보드에서 위에 추가한 Scene (혹은 ViewController)에 [다음] 버튼을 추가한다. 우측 옆에 한 단계 더 표현하기 위한 ViewController를 추가하고 배경 색상을 다른 색상으로 변경한다. 위와 마찬가지로 [다음]버튼에서 새 Scene으로 Segue를 연결한다.
  - [x] 예를 들어 First Scene 다음에 추가한 화면이 Yellow 화면이었다면, First Scene에서 [다음] 버튼을 누르면 Yellow 화면이 표시되고, Yellow 화면에서 [다음] 버튼을 누르면 Blue 화면이 나오는 방식으로 두 단계 표시한다.

## 📱 실행 화면

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/95578975/154428641-3af1b989-99d7-4e87-a03a-d2316c14c2de.gif)

## ✏️ 추가 학습 거리

### Action Segue 종류 정리

Show, Show Detail은 동일하다. 다만 Show Detail은 UISplitViewController에서 다르게 적용된다.

#### Show

이 segue는 타겟 뷰 컨트롤러의 [showViewController:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621377-showviewcontroller) 메소드를 이용하여 새 콘텐츠를 표시한다. 대부분의 뷰 컨트롤러의 경우, 이 segue가 소스 뷰 컨트롤러를 통해 새 콘텐츠를 modally하게 보여준다. 일부 뷰 컨트롤러는 메소드를 오버라이드하여 다른 동작을 구현하는 데 상요한다. 예를 들어, 네비게이션 컨트롤러는 새로운 뷰 컨트롤러를 navigation stack에 push 한다.

UIKit은 [targetViewControllerForAction:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621415-targetviewcontroller) 메소드를 사용하여 소스 뷰 컨트롤러를 위치시킨다.

#### Show Detail

이 segue는 타겟 뷰 컨트롤러의 [showViewController:sender:](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621377-showviewcontroller) 메소드를 이용하여 새 콘텐츠를 표시한다. 이 segue는 UISplitViewController 객체에 내장된 뷰 컨트롤러에만 적용된다. 이 segue를 사용하면 분할 뷰 컨트롤러가 두번째 하위 뷰 컨트롤러 (디테일 뷰 컨트롤러)를 새 콘텐츠로 교체한다. 대부분의 다른 뷰 컨트롤러는 새 컨텐츠를 modally하게 표시한다.

[Example 1](https://stackoverflow.com/questions/26287247/what-are-the-differences-between-segues-show-show-detail-present-modally): In Mail on iPad in landscape, tapping an email in the sidebar replaces the view controller on the right to show the new email.

[Example 2](https://stackoverflow.com/questions/25966215/whats-the-difference-between-all-the-selection-segues): In Messages, tapping a conversation will show the conversation details - replacing the view controller on the right when in a two column layout, or push the conversation when in a single column layout

#### Present Modally

이 segue는 지정된 표시 및 변환 스타일을 사용하여 뷰 컨트롤러를 modally하게 표시한다. 적절한 presentation context를 정의하는 뷰 컨트롤러가 실제 presentation을 처리한다.

#### Present As Popover

수평으로 규칙적인 환경에서 뷰 컨트롤러는 popover로 나타난다. 수평으로 compact한 환경에서 뷰 컨트롤러는 full-screen modal presentation을 사용하여 표시한다.

#### Custom

Interface Builder는 뷰 컨트롤러를 표시하는 것부터 popover로 화면을 컨트롤러에 표시하는 것까지 하나의 뷰 컨트롤러에서 다른 뷰 컨트롤러로 전환하는 모든 표준 방법에 대한 segue를 제공한다. 그러나 내가 원하는 segue가 없을 경우, custom segue를 만들 수 있다.

##### Implementing a Custom Segue

Custom segue를 구현하려면, `UIStoryboardSegue` 를 subclass하고, 아래 메소드들을 구현하면 된다.

- `initWithIdentifier:source:destination:` 메소드를 오버라이드해서 custom segue 객체를 초기화하는데 사용한다. 항상 super를 먼저 호출한다.

- `perform` 메소드를 구현하여 전환 애니메이션을 구성하는데 사용한다.

![image](https://user-images.githubusercontent.com/95578975/154425681-c3d9a646-62b6-4716-938a-d9a74394bb1e.png)



위의 Action Segue들의 실행화면은 모두 같았습니다. 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/95578975/154419697-58b6459b-2da6-4e79-b713-84ff619b9f83.gif)



그래서 이번엔 아이패드로 변경하여 실행해보았습니다.

그 결과, Show, Show Detail, Present Modally는 모두 아래와 같은 화면이 실행되었습니다.

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/95578975/154429795-e269ca6e-0691-4aed-bc54-07d9fb63fe2d.gif)



Present As Popover은 아래와 같은 화면이 나왔습니다.

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/95578975/154429800-6a19a0e2-8bcc-49d6-a42f-36ec45a85f45.gif)

## 🤔 고민과 해결

- Show Detail이 정확히 어떤 방식으로 동작하는지 이해가 잘 되지 않아서 자료를 찾아도 보고, 그룹 리뷰 시간에 질문했습니다. 다른 분들이 좋은 예시를 찾아주셔서 이해를 하긴 했지만 직접 다시 확인해보아야할 것 같습니다.


## 💡 학습 키워드

- [Using Segues](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/UsingSegues.html)

- [Modality](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/modality/)
- [Popover](https://developer.apple.com/design/human-interface-guidelines/ios/views/popovers/)