### PR TITLE
[Mase] Step5 - ViewController 연결하기

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E5400DA27BD5CC900434955 /* YellowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5400D927BD5CC900434955 /* YellowViewController.swift */; };
 		1EB1326E27B9EB140052C0F6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1326D27B9EB140052C0F6 /* AppDelegate.swift */; };
 		1EB1327027B9EB140052C0F6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */; };
 		1EB1327227B9EB140052C0F6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1327127B9EB140052C0F6 /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1E5400D927BD5CC900434955 /* YellowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YellowViewController.swift; sourceTree = "<group>"; };
 		1EB1326A27B9EB140052C0F6 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EB1326D27B9EB140052C0F6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 				1EB1326D27B9EB140052C0F6 /* AppDelegate.swift */,
 				1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */,
 				1EB1327127B9EB140052C0F6 /* ViewController.swift */,
+				1E5400D927BD5CC900434955 /* YellowViewController.swift */,
 				1EB1327327B9EB140052C0F6 /* Main.storyboard */,
 				1EB1327627B9EB150052C0F6 /* Assets.xcassets */,
 				1EB1327827B9EB150052C0F6 /* LaunchScreen.storyboard */,
@@ -138,6 +141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E5400DA27BD5CC900434955 /* YellowViewController.swift in Sources */,
 				1EB1327227B9EB140052C0F6 /* ViewController.swift in Sources */,
 				1EB1326E27B9EB140052C0F6 /* AppDelegate.swift in Sources */,
 				1EB1327027B9EB140052C0F6 /* SceneDelegate.swift in Sources */,

--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1E5400DA27BD5CC900434955 /* YellowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5400D927BD5CC900434955 /* YellowViewController.swift */; };
+		1E5400DC27BD652300434955 /* BlueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5400DB27BD652300434955 /* BlueViewController.swift */; };
 		1EB1326E27B9EB140052C0F6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1326D27B9EB140052C0F6 /* AppDelegate.swift */; };
 		1EB1327027B9EB140052C0F6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */; };
 		1EB1327227B9EB140052C0F6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB1327127B9EB140052C0F6 /* ViewController.swift */; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		1E5400D927BD5CC900434955 /* YellowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YellowViewController.swift; sourceTree = "<group>"; };
+		1E5400DB27BD652300434955 /* BlueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueViewController.swift; sourceTree = "<group>"; };
 		1EB1326A27B9EB140052C0F6 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EB1326D27B9EB140052C0F6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 				1EB1326F27B9EB140052C0F6 /* SceneDelegate.swift */,
 				1EB1327127B9EB140052C0F6 /* ViewController.swift */,
 				1E5400D927BD5CC900434955 /* YellowViewController.swift */,
+				1E5400DB27BD652300434955 /* BlueViewController.swift */,
 				1EB1327327B9EB140052C0F6 /* Main.storyboard */,
 				1EB1327627B9EB150052C0F6 /* Assets.xcassets */,
 				1EB1327827B9EB150052C0F6 /* LaunchScreen.storyboard */,
@@ -144,6 +147,7 @@
 				1E5400DA27BD5CC900434955 /* YellowViewController.swift in Sources */,
 				1EB1327227B9EB140052C0F6 /* ViewController.swift in Sources */,
 				1EB1326E27B9EB140052C0F6 /* AppDelegate.swift in Sources */,
+				1E5400DC27BD652300434955 /* BlueViewController.swift in Sources */,
 				1EB1327027B9EB140052C0F6 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -53,7 +53,6 @@
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 <connections>
                                     <action selector="nextButtonTouched:" destination="2sk-aB-aUq" eventType="touchUpInside" id="Eq6-70-1Nw"/>
-                                    <segue destination="LDJ-Xy-oFr" kind="show" id="jEU-7V-RUq"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -92,13 +91,13 @@
         <!--Yellow View Controller-->
         <scene sceneID="a2r-HW-Jnh">
             <objects>
-                <viewController id="LDJ-Xy-oFr" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="YellowViewController" id="LDJ-Xy-oFr" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="43b-dm-oDQ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o7A-cy-Dz4">
-                                <rect key="frame" x="183" y="405.5" width="48.5" height="31"/>
+                                <rect key="frame" x="183" y="432.5" width="48.5" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="다음">
                                     <backgroundConfiguration key="background" cornerRadius="10">
@@ -106,7 +105,7 @@
                                     </backgroundConfiguration>
                                 </buttonConfiguration>
                                 <connections>
-                                    <segue destination="b4p-1P-gk9" kind="show" id="1KN-wA-FHp"/>
+                                    <action selector="nextButtonTouched:" destination="LDJ-Xy-oFr" eventType="touchUpInside" id="JAk-w4-wSt"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aka-eA-cMc">
@@ -138,9 +137,9 @@
         <!--Blue View Controller-->
         <scene sceneID="J6S-dM-KiR">
             <objects>
-                <viewController id="b4p-1P-gk9" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BlueViewController" id="b4p-1P-gk9" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="55c-H1-G7E">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="69C-D2-hYa">

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -89,10 +89,10 @@
             </objects>
             <point key="canvasLocation" x="-97" y="-248"/>
         </scene>
-        <!--View Controller-->
+        <!--Yellow View Controller-->
         <scene sceneID="a2r-HW-Jnh">
             <objects>
-                <viewController id="LDJ-Xy-oFr" sceneMemberID="viewController">
+                <viewController id="LDJ-Xy-oFr" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="43b-dm-oDQ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -104,6 +104,12 @@
                                 <connections>
                                     <segue destination="b4p-1P-gk9" kind="show" id="1KN-wA-FHp"/>
                                 </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aka-eA-cMc">
+                                <rect key="frame" x="297" y="63" width="67" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Pl8-u7-msj"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -100,7 +100,11 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o7A-cy-Dz4">
                                 <rect key="frame" x="183" y="405.5" width="48.5" height="31"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="다음"/>
+                                <buttonConfiguration key="configuration" style="plain" title="다음">
+                                    <backgroundConfiguration key="background" cornerRadius="10">
+                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </backgroundConfiguration>
+                                </buttonConfiguration>
                                 <connections>
                                     <segue destination="b4p-1P-gk9" kind="show" id="1KN-wA-FHp"/>
                                 </connections>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -110,6 +110,9 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="LDJ-Xy-oFr" eventType="touchUpInside" id="TfB-QX-aQ8"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Pl8-u7-msj"/>
@@ -120,6 +123,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="jQf-t0-EOG"/>
+                    <connections>
+                        <outlet property="closeButton" destination="Aka-eA-cMc" id="N4e-ga-rHq"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iKS-mO-KgO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -131,17 +131,31 @@
             </objects>
             <point key="canvasLocation" x="1475" y="-524"/>
         </scene>
-        <!--View Controller-->
+        <!--Blue View Controller-->
         <scene sceneID="J6S-dM-KiR">
             <objects>
-                <viewController id="b4p-1P-gk9" sceneMemberID="viewController">
+                <viewController id="b4p-1P-gk9" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="55c-H1-G7E">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="69C-D2-hYa">
+                                <rect key="frame" x="307" y="60" width="67" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="b4p-1P-gk9" eventType="touchUpInside" id="BEZ-ey-mpx"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="aWU-ok-fUu"/>
                         <color key="backgroundColor" systemColor="systemBlueColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="Ssl-b3-k3P"/>
+                    <connections>
+                        <outlet property="closeButton" destination="69C-D2-hYa" id="5zQ-a2-iEm"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lgi-Qk-Tsz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -15,6 +15,8 @@ class BlueViewController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
     override func viewDidLoad() {
+        print("\nBlueViewController가 로드되었다.")
+        print(#file, #line, #function, #column)
         super.viewDidLoad()
         
         closeButton.translatesAutoresizingMaskIntoConstraints = false
@@ -25,5 +27,25 @@ class BlueViewController: UIViewController {
         
         closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
         closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        print("BlueViewController가 나타날 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("BlueViewController가 나타났다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        print("\nBlueViewController가 사라질 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        print("BlueViewController가 사라졌다.")
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -9,8 +9,21 @@ import UIKit
 
 class BlueViewController: UIViewController {
     
+    @IBOutlet weak var closeButton: UIButton!
+    
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        closeButton.setTitle("닫기", for: .normal)
+        closeButton.backgroundColor = .lightGray
+        closeButton.layer.cornerRadius = 10
+        
+        closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+        closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
     }
 }

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -1,0 +1,16 @@
+//
+//  BlueViewController.swift
+//  PhotoFrame
+//
+//  Created by 김상혁 on 2022/02/17.
+//
+
+import UIKit
+
+class BlueViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -20,6 +20,9 @@ class ViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        print("\nViewController가 로드되었다.")
+        print(#file, #line, #function, #column)
+        
         super.viewDidLoad()
         view.backgroundColor = .systemTeal
         
@@ -57,4 +60,25 @@ class ViewController: UIViewController {
         nextButton.centerYAnchor.constraint(equalTo: photoLabel.topAnchor, constant: -50).isActive = true
         
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        print("ViewController가 나타날 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("ViewController가 나타났다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        print("\nViewController가 사라질 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        print("ViewController가 사라졌다.")
+        print(#file, #line, #function, #column)
+    }
+    
 }

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -19,8 +19,8 @@ class ViewController: UIViewController {
         photoLabel.alpha = 0.6
         
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "YellowViewController") as? YellowViewController else { return }
-        nextVC.modalTransitionStyle = .flipHorizontal
-        nextVC.modalPresentationStyle = .automatic
+        nextVC.modalTransitionStyle = .partialCurl
+        nextVC.modalPresentationStyle = .fullScreen
         self.present(nextVC, animated: true, completion: nil)
     }
     

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -17,6 +17,11 @@ class ViewController: UIViewController {
         photoLabel.textColor = .systemPink
         photoLabel.backgroundColor = .systemBlue
         photoLabel.alpha = 0.6
+        
+        guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "YellowViewController") as? YellowViewController else { return }
+        nextVC.modalTransitionStyle = .flipHorizontal
+        nextVC.modalPresentationStyle = .automatic
+        self.present(nextVC, animated: true, completion: nil)
     }
     
     override func viewDidLoad() {

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -15,6 +15,8 @@ class YellowViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        print("\nYellowViewController가 로드되었다.")
+        print(#file, #line, #function, #column)
         super.viewDidLoad()
         closeButton.setTitle("닫기", for: .normal)
         closeButton.backgroundColor = .lightGray
@@ -24,5 +26,25 @@ class YellowViewController: UIViewController {
         
         closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
         closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        print("YellowViewController가 나타날 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("YellowViewController가 나타났다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        print("\nYellowViewController가 사라질 것이다.")
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        print("YellowViewController가 사라졌다.")
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -17,6 +17,8 @@ class YellowViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         closeButton.setTitle("닫기", for: .normal)
+        closeButton.backgroundColor = .lightGray
+        closeButton.layer.cornerRadius = 10
         
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -1,0 +1,17 @@
+//
+//  YellowViewController.swift
+//  PhotoFrame
+//
+//  Created by 김상혁 on 2022/02/17.
+//
+
+import UIKit
+
+class YellowViewController: UIViewController {
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -9,6 +9,13 @@ import UIKit
 
 class YellowViewController: UIViewController {
 
+    @IBAction func nextButtonTouched(_ sender: Any) {
+        guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "BlueViewController") as? BlueViewController else { return }
+        nextVC.modalTransitionStyle = .crossDissolve
+        nextVC.modalPresentationStyle = .automatic
+        self.present(nextVC, animated: true, completion: nil)
+    }
+    
     @IBOutlet weak var closeButton: UIButton!
     @IBAction func closeButtonTouched(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -9,9 +9,18 @@ import UIKit
 
 class YellowViewController: UIViewController {
 
-
+    @IBOutlet weak var closeButton: UIButton!
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        closeButton.setTitle("닫기", for: .normal)
         
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+        closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ self.firstLabel.text = "Mase의 사진액자"
 <br>
 <br>
 
-# **기능요구사항**
+## **기능요구사항**
 - [x] 사진액자 - IBOutlet 요구사항을 구현한 상태로 시작한다.
 - [x] First Scene에 버튼(UIButton)을 추가하고 IBAction으로 연결한다.
 - [x] 연결한 액션에 대한 메서드를 구현한다.
 - [x] 실행하고 버튼을 터치하기 이전/이후 화면을 캡처해서 readme.md 파일에 포함한다.
 
-# **프로그래밍 요구사항**
+## **프로그래밍 요구사항**
 - [x] Main.storyboard 에서 First Scene에 UIButton을 추가한다.
     - [x] 우측 유틸리티 영역 하단 3번째 탭 - 객체 라이브러리(Object Library)에서 Button 을 찾아서 View로 드래그한다.
     - [x] 방금 추가한 버튼을 선택하고 우측 유틸리티 영역 상단 4번째 탭 - 속성(Attributes)에서 Title을 `다음`으로 변경한다.
@@ -129,7 +129,7 @@ self.firstLabel.text = "Mase의 사진액자"
 <br>
 <br>
 
-# **기능요구사항**
+## **기능요구사항**
 
 - [x] 사진액자 - IBAction 요구사항을 구현한 상태로 시작한다.
 - [x] 스토리보드 구성 요소에 대해 학습하고 새로운 Scene과 Segue를 추가한다.
@@ -137,7 +137,7 @@ self.firstLabel.text = "Mase의 사진액자"
 
 <br>
 
-# **프로그래밍 요구사항**
+## **프로그래밍 요구사항**
 
 - [x] Main 스토리보드에서 First Scene 옆에 ViewController를 드래그해서 새로운 Scene을 추가한다.
 - [x] 앞 단계에서 추가한 [다음]버튼을 선택하고 `Control + 드래그`를 해서 새로 추가한 Scene에 연결한다.
@@ -148,3 +148,53 @@ self.firstLabel.text = "Mase의 사진액자"
 - [x] 다시 스토리보드에서 위에 추가한 Scene (혹은 ViewController)에 [다음] 버튼을 추가한다.
 - [x] 우측 옆에 한 단계 더 표현하기 위한 ViewController를 추가하고 배경 색상을 다른 색상으로 변경한다.<br>위와 마찬가지로 [다음]버튼에서 새 Scene으로 Segue를 연결한다.
     - [x] 예를 들어 First Scene 다음에 추가한 화면이 Yellow 화면이었다면,<br>First Scene에서 [다음] 버튼을 누르면 Yellow 화면이 표시되고,<br>Yellow 화면에서 [다음] 버튼을 누르면 Blue 화면이 나오는 방식으로 두 단계 표시한다.
+
+<br>
+<br>
+
+# 5. View Controller 연결하기
+### 완성 날짜
+- 02월 17일 15:15
+
+<br>
+
+### 완성 화면 
+<img src="https://user-images.githubusercontent.com/57667738/154415994-c240ce43-d5f6-452e-af06-762b42f96a22.gif" width="50%" />
+
+<br>
+<br>
+
+## **기능요구사항**
+
+- [x] 사진액자 - Scene과 Segue 요구사항을 구현한 상태로 시작한다.
+- [x] 스토리보드 구성 요소와 클래스 코드와 연결해서 동작을 확장한다.
+- [x] 실행하고 새로운 화면을 캡처해서 readme.md 파일에 포함한다.
+
+## **프로그래밍 요구사항**
+
+- [x] 프로젝트에 새로운 ViewController 클래스를 추가한다. File > New... > File... 메뉴를 선택한다. 다음과 같은 화면에서 Cocoa Touch Class를 선택한다.
+- [x] 다음과 같이 UIViewController에서 상속받도록 입력하고, 원하는 클래스명을 입력한다. (예시 YellowViewController)
+- [x] 다음 화면에서는 프로젝트내 어떤 경로에 저장하며, 프로젝트 그룹/타깃에 저장할 것인지 선택한다.
+    - [x] 하위 디렉토리가 있거나 원하는 하위 그룹이 있으면 변경할 수 있다.
+    - [x] 빌드하는 타깃이 여러 개인 경우, 복수로 선택할 수도 있다.
+- [x] 스토리보드에서 새로 추가한 Scene을 선택하고, 우측 유틸리티 영역 3번째 Identity 탭을 선택한다.
+    - [x] Custom Class > Class 항목에 `YellowViewController` (자신이 생성한 클래스 이름)을 지정한다.
+    - [x] 자동완성이 되야 클래스가 제대로 생성된 것이다. 자동완성이 안된다면 앞 단계를 다시 확인해서 UIViewController에서 상속 받도록 만들었는지 확인하고 클래스를 다시 만든다.
+- [x] 이제 스토리보드에서 YellowViewController 화면에 [닫기] 버튼을 추가한다.
+- [x] Assistant Editor를 선택하고 [닫기] 버튼에 대한 IBAction 액션을 연결한다.
+    - [x] 만약 방금 추가한 `YellowViewController` (혹은 자신이 생성한 클래스)가 우측에 자동으로 연결되지 않으면 Custom Class가 정상적으로 연결되지 않았거나
+    - [x] 우측 Assistant 편집기 상단에 점프바(JumpBar)에 `Automatic` 이라고 선택되어 있는지 확인한다. 다른 상태인 경우 `Automatic`으로 변경한다.
+- [x] IBAction 이름은 `closeButtonTouched`로 지정하고 다음과 같이 코드를 작성한다.
+
+```swift
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+```
+
+- [x] 위와 동일하게 세 번째 추가한 화면에 대해 ViewController 클래스를 지정하고, [닫기]버튼을 추가하고, 액션을 연결해서 화면을 닫는 동작이 동작하도록 구현한다.
+- [x] 뷰 컨트롤러 강의 자료에 있는 화면 관련 콜백 함수들에 모두 `print(#file, #line, #function, #column)` 코드를 추가한다.
+    - viewWillAppear()
+    - viewDidAppear()
+    - viewWillDisappear()
+    - viewDidDisappear()


### PR DESCRIPTION
## 학습 키워드
-ViewController
- View LifeCycle
- dismiss
- Assistant, Automatic
- Storyboard ID

## 작업 목록
- [x] BlueViewController에 closeButton 추가
- [x] closeButton 터치시 View가 사라지도록 코드 작성
- [x] ViewController의 LifeCycle 관련 콜백 함수를 작성
- [x] View가 생성, 소멸될 때 마다 콘솔에 나타나는 반응 확인

## 고민과 해결
- *코드로 Segue 구현 중 ViewController를 생성하는 코드에서 궁금한 점이 생김*
	```swift
	guard let blueVC = self.storyboard?.instantiateViewController(withIdentifier: "BlueViewController") as? BlueViewController else { return }
	```

	- *Storyboard ID란 무엇인가?*
                          <img width="380" alt="CleanShot 2022-02-17 at 16 45 15@2x" src="https://user-images.githubusercontent.com/57667738/154429272-fce3b4e4-26e4-446e-b1c1-cf9de9239806.png">
			: 여기서 말하는 identifier란 Storyboard상에서 ViewController를 구분할 수 있게 해주는 식별자이다.
			Storyboard상에서 어떤 ViewController의 데이터로 UIViewController 객체를 생성 및 초기화할 것인지 정하기 위해 사용한다.

	- *왜 끝에 `as? BlueViewController`를 붙이는가?*
		: `as? BlueViewController`를 붙이지 않으면 단순히 `UIViewController`타입의 객체만을 생성한 것일 뿐이므로
			`blueVC.`를 통해 BlueViewController의 프로퍼티나 메소드에는 접근할 수 없다.
			`instantiateViewController` 메소드의 반환값을 확인해 보면 `UIViewController`인 것을 알 수 있으며
			따라서 `BlueViewController`로 타입 캐스팅이 필요한 것이다.


- *`modalTransitionStyle`을 하나씩 바꿔가며 시도해보다 `.partialCurl`을 선택할 때만 Crash 발생*
  : 공식 문서를 읽어보니 partialCurl은 Presenting이 Full-Screen일 경우에만 지원하는 스타일이라고 되어있다.
    여기서 말하는 Full-Screen이 무엇인지 헤매다 `.modalPresentationStyle`의 타입이라는 것을 알았다.

    ```swift
    nextVC.modalTransitionStyle = .partialCurl
    nextVC.modalPresentationStyle = .fullScreen
    ```
    이렇게 presenting할 VC의 Style을 `fullScreen`으로 지정해줘야, 해당 VC를 `partialCurl` Style로 넘길 수 있다.
