### PR TITLE
[Mase] - Step6 NavigationController 구현

### DIFF
--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
             </objects>
             <point key="canvasLocation" x="767" y="151"/>
         </scene>
-        <!--Item 1-->
+        <!--View Controller-->
         <scene sceneID="QvG-fU-dV5">
             <objects>
                 <viewController id="2sk-aB-aUq" customClass="ViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
@@ -59,7 +59,7 @@
                         <viewLayoutGuide key="safeArea" id="0pz-Xa-SLm"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item 1" id="MY7-Db-kBn"/>
+                    <navigationItem key="navigationItem" id="qL3-Zi-9iw"/>
                     <connections>
                         <outlet property="firstDescription" destination="l9w-aX-GIY" id="dUD-wH-NGu"/>
                         <outlet property="nextButton" destination="yUM-bq-z0n" id="Zgk-tw-MJx"/>
@@ -68,7 +68,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="529-3e-Zot" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="767" y="-523"/>
+            <point key="canvasLocation" x="1676.8115942028987" y="-523.66071428571422"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="mcT-CM-0tq">
@@ -80,7 +80,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="2sk-aB-aUq" kind="relationship" relationship="viewControllers" id="5uQ-Jz-5dn"/>
+                        <segue destination="qUo-23-ueA" kind="relationship" relationship="viewControllers" id="5uQ-Jz-5dn"/>
                         <segue destination="F3k-Ml-ly3" kind="relationship" relationship="viewControllers" id="5Zy-Kc-AaW"/>
                     </connections>
                 </tabBarController>
@@ -132,7 +132,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iKS-mO-KgO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1475" y="-524"/>
+            <point key="canvasLocation" x="2384.057971014493" y="-524.33035714285711"/>
         </scene>
         <!--Blue View Controller-->
         <scene sceneID="J6S-dM-KiR">
@@ -174,7 +174,26 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lgi-Qk-Tsz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <exit id="22j-NF-bwm" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="2199" y="-524"/>
+            <point key="canvasLocation" x="3108.6956521739135" y="-524.33035714285711"/>
+        </scene>
+        <!--Item 1-->
+        <scene sceneID="zAV-RL-oco">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="qUo-23-ueA" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item 1" id="MY7-Db-kBn"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ETs-SK-vTh">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="2sk-aB-aUq" kind="relationship" relationship="rootViewController" id="bTJ-p9-yhC"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="HxF-Es-B79" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="766.66666666666674" y="-523.66071428571422"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -151,6 +151,15 @@
                                     <action selector="closeButtonTouched:" destination="b4p-1P-gk9" eventType="touchUpInside" id="BEZ-ey-mpx"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vtb-eD-2Wu">
+                                <rect key="frame" x="51" y="810" width="67" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="unwindButtonTouched:" destination="b4p-1P-gk9" eventType="touchUpInside" id="mu7-VJ-sUq"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="aWU-ok-fUu"/>
                         <color key="backgroundColor" systemColor="systemBlueColor"/>
@@ -158,9 +167,12 @@
                     <navigationItem key="navigationItem" id="Ssl-b3-k3P"/>
                     <connections>
                         <outlet property="closeButton" destination="69C-D2-hYa" id="5zQ-a2-iEm"/>
+                        <outlet property="unwindButton" destination="vtb-eD-2Wu" id="EHH-Xp-iuw"/>
+                        <segue destination="22j-NF-bwm" kind="unwind" identifier="unwindVC" unwindAction="unwindVCWithSegue:" id="TBr-Ro-dhm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lgi-Qk-Tsz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="22j-NF-bwm" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="2199" y="-524"/>
         </scene>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -158,6 +158,7 @@
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 <connections>
                                     <action selector="unwindButtonTouched:" destination="b4p-1P-gk9" eventType="touchUpInside" id="mu7-VJ-sUq"/>
+                                    <segue destination="22j-NF-bwm" kind="unwind" unwindAction="unwindToFirstSceneWithSegue:" id="t7g-Zb-Uss"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -168,7 +169,6 @@
                     <connections>
                         <outlet property="closeButton" destination="69C-D2-hYa" id="5zQ-a2-iEm"/>
                         <outlet property="unwindButton" destination="vtb-eD-2Wu" id="EHH-Xp-iuw"/>
-                        <segue destination="22j-NF-bwm" kind="unwind" identifier="unwindVC" unwindAction="unwindVCWithSegue:" id="TBr-Ro-dhm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lgi-Qk-Tsz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -185,6 +185,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ETs-SK-vTh">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -44,9 +44,6 @@ class BlueViewController: UIViewController {
         unwindButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -30).isActive = true
     }
     
-    
-    
-    
     override func viewWillAppear(_ animated: Bool) {
         print("BlueViewController가 나타날 것이다.")
         print(#file, #line, #function, #column)

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -12,12 +12,12 @@ class BlueViewController: UIViewController {
     @IBOutlet weak var closeButton: UIButton!
     
     @IBAction func closeButtonTouched(_ sender: Any) {
-        self.dismiss(animated: true, completion: nil)
+        navigationController?.popViewController(animated: true)
     }
     
     @IBOutlet weak var unwindButton: UIButton!
     @IBAction func unwindButtonTouched(_ sender: Any) {
-        performSegue(withIdentifier: "unwindVC", sender: self)
+        navigationController?.popToRootViewController(animated: true)
     }
     
     override func viewDidLoad() {
@@ -27,23 +27,21 @@ class BlueViewController: UIViewController {
         
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         unwindButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        
+    
         closeButton.setTitle("닫기", for: .normal)
         closeButton.backgroundColor = .lightGray
         closeButton.layer.cornerRadius = 10
-        
-        closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
-        closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
-        
     
+        closeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30).isActive = true
+        closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30).isActive = true
+        
+
         unwindButton.setTitle("초기화면으로 돌아가기", for: .normal)
         unwindButton.backgroundColor = .lightGray
         unwindButton.layer.cornerRadius = 10
         
-        unwindButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
-        unwindButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -30).isActive = true
-        
+        unwindButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 30).isActive = true
+        unwindButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -30).isActive = true
     }
     
     

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -14,12 +14,20 @@ class BlueViewController: UIViewController {
     @IBAction func closeButtonTouched(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
+    
+    @IBOutlet weak var unwindButton: UIButton!
+    @IBAction func unwindButtonTouched(_ sender: Any) {
+        performSegue(withIdentifier: "unwindVC", sender: self)
+    }
+    
     override func viewDidLoad() {
         print("\nBlueViewController가 로드되었다.")
         print(#file, #line, #function, #column)
         super.viewDidLoad()
         
         closeButton.translatesAutoresizingMaskIntoConstraints = false
+        unwindButton.translatesAutoresizingMaskIntoConstraints = false
+        
         
         closeButton.setTitle("닫기", for: .normal)
         closeButton.backgroundColor = .lightGray
@@ -27,7 +35,19 @@ class BlueViewController: UIViewController {
         
         closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
         closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
+        
+    
+        unwindButton.setTitle("초기화면으로 돌아가기", for: .normal)
+        unwindButton.backgroundColor = .lightGray
+        unwindButton.layer.cornerRadius = 10
+        
+        unwindButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
+        unwindButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -30).isActive = true
+        
     }
+    
+    
+    
     
     override func viewWillAppear(_ animated: Bool) {
         print("BlueViewController가 나타날 것이다.")

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -21,9 +21,10 @@ class BlueViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         print("\nBlueViewController가 로드되었다.")
         print(#file, #line, #function, #column)
-        super.viewDidLoad()
+         
         
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         unwindButton.translatesAutoresizingMaskIntoConstraints = false
@@ -45,21 +46,25 @@ class BlueViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         print("BlueViewController가 나타날 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         print("BlueViewController가 나타났다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         print("\nBlueViewController가 사라질 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         print("BlueViewController가 사라졌다.")
         print(#file, #line, #function, #column)
     }

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -24,10 +24,10 @@ class ViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         print("\nViewController가 로드되었다.")
         print(#file, #line, #function, #column)
         
-        super.viewDidLoad()
         view.backgroundColor = .systemTeal
         
         photoLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -65,21 +65,25 @@ class ViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         print("ViewController가 나타날 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         print("ViewController가 나타났다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         print("\nViewController가 사라질 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         print("ViewController가 사라졌다.")
         print(#file, #line, #function, #column)
     }

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -62,7 +62,6 @@ class ViewController: UIViewController {
         
         nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         nextButton.centerYAnchor.constraint(equalTo: photoLabel.topAnchor, constant: -50).isActive = true
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -84,5 +83,4 @@ class ViewController: UIViewController {
         print("ViewController가 사라졌다.")
         print(#file, #line, #function, #column)
     }
-    
 }

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -19,12 +19,9 @@ class ViewController: UIViewController {
         photoLabel.alpha = 0.6
         
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "YellowViewController") as? YellowViewController else { return }
-        nextVC.modalTransitionStyle = .coverVertical
-        nextVC.modalPresentationStyle = .automatic
-        self.present(nextVC, animated: true, completion: nil)
+        
+        navigationController?.pushViewController(nextVC, animated: true)
     }
-    
-    @IBAction func unwindVC(segue: UIStoryboardSegue) {}
     
     override func viewDidLoad() {
         print("\nViewController가 로드되었다.")

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -19,10 +19,12 @@ class ViewController: UIViewController {
         photoLabel.alpha = 0.6
         
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "YellowViewController") as? YellowViewController else { return }
-        nextVC.modalTransitionStyle = .partialCurl
-        nextVC.modalPresentationStyle = .fullScreen
+        nextVC.modalTransitionStyle = .coverVertical
+        nextVC.modalPresentationStyle = .automatic
         self.present(nextVC, animated: true, completion: nil)
     }
+    
+    @IBAction func unwindVC(segue: UIStoryboardSegue) {}
     
     override func viewDidLoad() {
         print("\nViewController가 로드되었다.")

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -20,9 +20,10 @@ class YellowViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         print("\nYellowViewController가 로드되었다.")
         print(#file, #line, #function, #column)
-        super.viewDidLoad()
+    
     
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         
@@ -35,21 +36,25 @@ class YellowViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         print("YellowViewController가 나타날 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         print("YellowViewController가 나타났다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         print("\nYellowViewController가 사라질 것이다.")
         print(#file, #line, #function, #column)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         print("YellowViewController가 사라졌다.")
         print(#file, #line, #function, #column)
     }

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -11,28 +11,27 @@ class YellowViewController: UIViewController {
 
     @IBAction func nextButtonTouched(_ sender: Any) {
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "BlueViewController") as? BlueViewController else { return }
-        nextVC.modalTransitionStyle = .crossDissolve
-        nextVC.modalPresentationStyle = .automatic
-        self.present(nextVC, animated: true, completion: nil)
+        navigationController?.pushViewController(nextVC, animated: true)
     }
     
     @IBOutlet weak var closeButton: UIButton!
     @IBAction func closeButtonTouched(_ sender: Any) {
-        self.dismiss(animated: true, completion: nil)
+        navigationController?.popViewController(animated: true)
     }
     
     override func viewDidLoad() {
         print("\nYellowViewController가 로드되었다.")
         print(#file, #line, #function, #column)
         super.viewDidLoad()
+    
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        
         closeButton.setTitle("닫기", for: .normal)
         closeButton.backgroundColor = .lightGray
         closeButton.layer.cornerRadius = 10
         
-        closeButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
-        closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30).isActive = true
+        closeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -30).isActive = true
+        closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30).isActive = true
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/README.md
+++ b/README.md
@@ -198,3 +198,83 @@ self.firstLabel.text = "Mase의 사진액자"
     - viewDidAppear()
     - viewWillDisappear()
     - viewDidDisappear()
+
+<br>
+<br>
+
+# 6. Container ViewController 활용하기
+### 완성 날짜
+- 02월 18일 15:25
+
+<br>
+
+### 완성 화면 
+<img src="https://user-images.githubusercontent.com/57667738/154629797-a644a300-2b10-46ae-aa3f-e4ee496ebe9f.gif" width="30%" />
+
+- [닫기]버튼 또는 [< Back]버튼을 누르면 이전 View로 돌아간다
+- 세 번째 View에서 [초기화면으로 돌아가기]버튼을 누르면 이전 View가 아닌 RootView로 돌아간다
+
+<br>
+<br>
+
+## **기능요구사항**
+
+- [x]  사진액자 - ViewController 요구사항을 구현한 상태로 시작한다.
+- [x]  내비게이션 컨트롤러(Navigation Controller)를 Embed 시켜서 동작하도록 개선한다.
+- [x]  실행하고 새로운 화면을 캡처해서 readme.md 파일에 포함한다.
+
+<br>
+
+## **프로그래밍 요구사항**
+
+- [x]  스토리보드에서 First Scene을 선택하고, Editor > Embed In > Navigation Controller 항목을 선택한다.
+- [x]  실행해보면 화면 상단에 내비게이션바(Navigation Bar)가 추가되고 [다음]버튼을 누르면 다음 화면이 우측에서 좌측으로 애니메이션되면서 표시된다.
+- [x]  [닫기]버튼에 연결된 `closeButtonTouched` 코드를 다음과 같이 수정한다.
+
+        @IBAction func closeButtonTouched(_ sender: Any) {
+            self.navigationController?.popViewController(animated: true)
+        }
+        
+- [x]  위와 동일하게 세 번째 추가한 화면에 [닫기]버튼도 코드를 수정한다.
+- [x]  뷰 컨트롤러 콜백 함수들 동작도 동일한지 확인한다.
+
+<br>
+
+## **추가학습거리**
+
+### 뷰컨트롤러 컨테이너는 또 어떤 클래스가 있는지 찾아보고 학습한다.
+- NavigationController
+    - Stack 기반의 container view controller이다.
+    - 제공하는 navigation 인터페이스로 1개 이상의 view controller를 관리할 수 있다.
+    - Stack 기반이므로 최상단에 있는 하나의 view controller만이 보여지게 되고<br>view controller를 push 혹은 pop을 통해 보여질 view controller를 결정한다.
+
+- TabBarController
+    - Selection에 따라 어떤 child view controller가 화면에 보여질 지 관리하는 Container view controller이다.
+
+- SplitViewController
+    - 화면을 분할해서 2개의 view controller를 함께 표현.
+    - 화면 왼쪽에 MasterViewController, 오른쪽에 DetailViewController가 있다.
+    - 다른 뷰컨트롤러 컨테이너들과 달리 Child의 수가 2개로 고정되어있다.
+
+- PageViewController
+    - 각 페이지가 Child View Controller에 의해 관리되는,<br>컨텐츠 페이지 간의 탐색을 관리하는 컨테이너 뷰 컨트롤러이다.
+    - 좌우로 Swipe하며 여러 view를 표시한다.
+
+<br>
+
+### 내비게이션 컨트롤러가 있을 경우와 없을 경우 화면 전환 동작이 어떻게 다른지, 화면들 포함관계가 있는지 학습한다.
+- NavigationController가 있을 경우
+    - 오른쪽에서 왼쪽으로 전환되는 방식(`Show`)으로 동작한다.
+    - NavigationController가 다른 View를 호출한다.
+    - 호출된 View는 Stack에 Push-Pop되며 Scene에 나타났다가 사라진다.
+    - pushViewController, popViewController메소드를 사용한다.
+
+- NavigationController가 없을 경우
+    - 아이폰에서는 항상 `Present Modally` 방식으로 전환된다.
+
+<br>
+
+### 내비게이션 컨트롤러 관련 메서드가 왜 push / pop 인지 학습한다.
+- View가 Stack형태로 쌓이는 구조이기 떄문이다.
+- 맨 마지막에 Scene에 올라온 View가 사용자에게 보이고, 해당 View를 Pop하면 직전에 쌓였던 View가 나타난다.
+- Navigation VC를 Embed한 View가 항상 Stack의 맨 첫 번째로 들어간다.


### PR DESCRIPTION
## 학습 키워드
- NavigationController
- ViewController Container
- pushViewController, popViewController
- safeAreaLayoutGuide


## 작업 목록
- [x] First Scene에 NavigationController를 Embed한다.
- [x] 나머지 Scene들도 NavigationController로 연결되게 구현한다.
- [x] [닫기]버튼의 코드도 NavigationController 방식에 맞게 수정한다.
- [x] ViewController 콜백함수의 동작함수 동작이 동일한지도 확인한다.

## 고민과 해결
### *NavigationController를 추가하니 [닫기]버튼이 동작하지 않음*
Segue방식의 `dismiss`가 아닌 `popViewController`를 사용해야했다.
또한 이전 View로 돌아가는 동작 뿐 아니라 RootView로 돌아는 동작,
다음 View를 띄우는 동작도 모두 Segue방식과 다르다는 것을 알게되었다.

예를 들어 Segue 방식은 새로운 ViewController 객체를 만든 뒤, 화면 전환 Style을 지정해서 present하는 방식이지만
NavigationViewController에서는 단순히 `pushViewController`에 매개변수로 넣어주기만 하면 된다.


### *화면에 NavigationController의 UI가 추가되자, 위 아래에 배치했던 버튼들이 NavigationController 영역을 침범함*
Constraint를 잡을 때 단순히 RootView가 아니라 RootView의 SafeArea를 기준으로 잡아줘야한다는 사실을 알게되었다.
예를 들어 topAnchor를 적용할 때는 `view.topAnchor`가 아닌, `view.safeAreaLayoutGuide.topAnchor`를 사용해야한다.