### PR TITLE
[Selina] Step5 - ViewController 연결하기 (1)

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05133F327BED97E006EED49 /* PinkViewController.swift */; };
 		D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA627BA678B009448A6 /* AppDelegate.swift */; };
 		D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */; };
 		D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEAA27BA678B009448A6 /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D05133F327BED97E006EED49 /* PinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinkViewController.swift; sourceTree = "<group>"; };
 		D0DFEEA327BA678B009448A6 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0DFEEA627BA678B009448A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				D0DFEEAF27BA678C009448A6 /* Assets.xcassets */,
 				D0DFEEB127BA678C009448A6 /* LaunchScreen.storyboard */,
 				D0DFEEB427BA678C009448A6 /* Info.plist */,
+				D05133F327BED97E006EED49 /* PinkViewController.swift */,
 			);
 			path = PhotoFrame;
 			sourceTree = "<group>";
@@ -138,6 +141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */,
 				D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */,
 				D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */,
 				D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */,

--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -9,6 +9,11 @@
 /* Begin PBXBuildFile section */
 		D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05133F327BED97E006EED49 /* PinkViewController.swift */; };
 		D05133F627BEDEB3006EED49 /* MintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05133F527BEDEB3006EED49 /* MintViewController.swift */; };
+		D06634F627BF791C005FB83E /* TestTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06634F527BF791C005FB83E /* TestTableViewController.swift */; };
+		D06634F827BF7959005FB83E /* SegueShowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06634F727BF7959005FB83E /* SegueShowViewController.swift */; };
+		D06634FA27BF7994005FB83E /* SegueModallyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06634F927BF7994005FB83E /* SegueModallyViewController.swift */; };
+		D06634FC27BF79E4005FB83E /* SeguePopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06634FB27BF79E4005FB83E /* SeguePopoverViewController.swift */; };
+		D066350027BF8122005FB83E /* SegueShowDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06634FF27BF8122005FB83E /* SegueShowDetailViewController.swift */; };
 		D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA627BA678B009448A6 /* AppDelegate.swift */; };
 		D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */; };
 		D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEAA27BA678B009448A6 /* ViewController.swift */; };
@@ -20,6 +25,11 @@
 /* Begin PBXFileReference section */
 		D05133F327BED97E006EED49 /* PinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinkViewController.swift; sourceTree = "<group>"; };
 		D05133F527BEDEB3006EED49 /* MintViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintViewController.swift; sourceTree = "<group>"; };
+		D06634F527BF791C005FB83E /* TestTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTableViewController.swift; sourceTree = "<group>"; };
+		D06634F727BF7959005FB83E /* SegueShowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueShowViewController.swift; sourceTree = "<group>"; };
+		D06634F927BF7994005FB83E /* SegueModallyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueModallyViewController.swift; sourceTree = "<group>"; };
+		D06634FB27BF79E4005FB83E /* SeguePopoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeguePopoverViewController.swift; sourceTree = "<group>"; };
+		D06634FF27BF8122005FB83E /* SegueShowDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegueShowDetailViewController.swift; sourceTree = "<group>"; };
 		D0DFEEA327BA678B009448A6 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0DFEEA627BA678B009448A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +79,11 @@
 				D0DFEEB427BA678C009448A6 /* Info.plist */,
 				D05133F327BED97E006EED49 /* PinkViewController.swift */,
 				D05133F527BEDEB3006EED49 /* MintViewController.swift */,
+				D06634F527BF791C005FB83E /* TestTableViewController.swift */,
+				D06634F727BF7959005FB83E /* SegueShowViewController.swift */,
+				D06634F927BF7994005FB83E /* SegueModallyViewController.swift */,
+				D06634FB27BF79E4005FB83E /* SeguePopoverViewController.swift */,
+				D06634FF27BF8122005FB83E /* SegueShowDetailViewController.swift */,
 			);
 			path = PhotoFrame;
 			sourceTree = "<group>";
@@ -144,11 +159,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D06634FC27BF79E4005FB83E /* SeguePopoverViewController.swift in Sources */,
 				D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */,
 				D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */,
+				D06634FA27BF7994005FB83E /* SegueModallyViewController.swift in Sources */,
+				D06634F827BF7959005FB83E /* SegueShowViewController.swift in Sources */,
 				D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */,
+				D066350027BF8122005FB83E /* SegueShowDetailViewController.swift in Sources */,
 				D05133F627BEDEB3006EED49 /* MintViewController.swift in Sources */,
 				D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */,
+				D06634F627BF791C005FB83E /* TestTableViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05133F327BED97E006EED49 /* PinkViewController.swift */; };
+		D05133F627BEDEB3006EED49 /* MintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05133F527BEDEB3006EED49 /* MintViewController.swift */; };
 		D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA627BA678B009448A6 /* AppDelegate.swift */; };
 		D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */; };
 		D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DFEEAA27BA678B009448A6 /* ViewController.swift */; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		D05133F327BED97E006EED49 /* PinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinkViewController.swift; sourceTree = "<group>"; };
+		D05133F527BEDEB3006EED49 /* MintViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintViewController.swift; sourceTree = "<group>"; };
 		D0DFEEA327BA678B009448A6 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0DFEEA627BA678B009448A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D0DFEEA827BA678B009448A6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -66,6 +68,7 @@
 				D0DFEEB127BA678C009448A6 /* LaunchScreen.storyboard */,
 				D0DFEEB427BA678C009448A6 /* Info.plist */,
 				D05133F327BED97E006EED49 /* PinkViewController.swift */,
+				D05133F527BEDEB3006EED49 /* MintViewController.swift */,
 			);
 			path = PhotoFrame;
 			sourceTree = "<group>";
@@ -144,6 +147,7 @@
 				D05133F427BED97E006EED49 /* PinkViewController.swift in Sources */,
 				D0DFEEAB27BA678B009448A6 /* ViewController.swift in Sources */,
 				D0DFEEA727BA678B009448A6 /* AppDelegate.swift in Sources */,
+				D05133F627BEDEB3006EED49 /* MintViewController.swift in Sources */,
 				D0DFEEA927BA678B009448A6 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -119,10 +119,10 @@
             </objects>
             <point key="canvasLocation" x="2035" y="-441"/>
         </scene>
-        <!--View Controller-->
+        <!--Mint View Controller-->
         <scene sceneID="4bZ-99-P3c">
             <objects>
-                <viewController id="obM-Ks-hqv" sceneMemberID="viewController">
+                <viewController id="obM-Ks-hqv" customClass="MintViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XnS-BX-rwm">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Test-->
         <scene sceneID="uyG-HV-U2a">
             <objects>
-                <tableViewController id="pb9-bq-Xnt" sceneMemberID="viewController">
+                <tableViewController id="pb9-bq-Xnt" customClass="TestTableViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="nuk-dg-xAf">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -178,7 +178,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="AXM-Ke-pEy" kind="show" id="viF-eB-hXG"/>
+                                            <segue destination="AXM-Ke-pEy" kind="presentation" id="viF-eB-hXG"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -278,10 +278,10 @@
             </objects>
             <point key="canvasLocation" x="3005.7971014492755" y="2284.8214285714284"/>
         </scene>
-        <!--View Controller-->
+        <!--Segue Popover View Controller-->
         <scene sceneID="63v-gj-4eq">
             <objects>
-                <viewController id="ANF-Ow-3Ja" sceneMemberID="viewController">
+                <viewController id="ANF-Ow-3Ja" customClass="SeguePopoverViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5d2-bD-dua">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -305,10 +305,10 @@
             </objects>
             <point key="canvasLocation" x="3104" y="1547"/>
         </scene>
-        <!--View Controller-->
+        <!--Segue Modally View Controller-->
         <scene sceneID="3Wc-io-r5B">
             <objects>
-                <viewController id="Ydl-NW-a1z" sceneMemberID="viewController">
+                <viewController id="Ydl-NW-a1z" customClass="SegueModallyViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="y2H-51-Vxz">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -333,10 +333,10 @@
             </objects>
             <point key="canvasLocation" x="2287" y="1301"/>
         </scene>
-        <!--View Controller-->
+        <!--Segue Show View Controller-->
         <scene sceneID="aFh-fl-KiD">
             <objects>
-                <viewController id="LNo-ec-s45" sceneMemberID="viewController">
+                <viewController id="LNo-ec-s45" customClass="SegueShowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="axw-dM-p5g">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -361,10 +361,10 @@
             </objects>
             <point key="canvasLocation" x="370" y="896"/>
         </scene>
-        <!--View Controller-->
+        <!--Segue Show Detail View Controller-->
         <scene sceneID="Nau-H3-XxS">
             <objects>
-                <viewController id="zP7-hJ-ZFK" sceneMemberID="viewController">
+                <viewController id="zP7-hJ-ZFK" customClass="SegueShowDetailViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5eZ-Qw-hfC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -554,11 +554,11 @@
             <objects>
                 <viewController modalTransitionStyle="partialCurl" id="AXM-Ke-pEy" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="DA6-fm-iDk">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Partial Curl" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuK-De-DGf">
-                                <rect key="frame" x="136.5" y="430" width="141" height="36"/>
+                                <rect key="frame" x="136.5" y="403" width="141" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -75,10 +75,10 @@
             </objects>
             <point key="canvasLocation" x="1142" y="-441"/>
         </scene>
-        <!--View Controller-->
+        <!--Pink View Controller-->
         <scene sceneID="mMR-Nx-J31">
             <objects>
-                <viewController id="fWP-MA-5AE" sceneMemberID="viewController">
+                <viewController id="fWP-MA-5AE" customClass="PinkViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1zk-pe-4jp">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eQ0-jb-ChL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PCs-63-X1z">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
@@ -8,6 +8,402 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Test-->
+        <scene sceneID="uyG-HV-U2a">
+            <objects>
+                <tableViewController id="pb9-bq-Xnt" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="nuk-dg-xAf">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <sections>
+                            <tableViewSection id="hZE-lg-jdn">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="2gp-Uo-AaE">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2gp-Uo-AaE" id="QTN-Cg-Hn2">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Segue: Show" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t82-rl-KRg">
+                                                    <rect key="frame" x="20" y="20" width="100" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="LNo-ec-s45" kind="show" id="7r1-BU-dZd"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="HX8-Dz-39a">
+                                        <rect key="frame" x="0.0" y="111.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HX8-Dz-39a" id="Ar2-0h-q5M">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Segue: Show Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3U-BH-1G4">
+                                                    <rect key="frame" x="20" y="20" width="148" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="zP7-hJ-ZFK" kind="showDetail" id="5Hm-F4-ClE"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="L2A-72-zda">
+                                        <rect key="frame" x="0.0" y="178.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="L2A-72-zda" id="g6c-OK-WyF">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Segue: Present Modally" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aBu-Jv-cuW">
+                                                    <rect key="frame" x="20" y="20" width="180" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Ydl-NW-a1z" kind="presentation" id="R2q-9m-hiW"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="Pl7-1O-GPX">
+                                        <rect key="frame" x="0.0" y="245.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pl7-1O-GPX" id="ZmL-nE-tMy">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Segue: Present As Popover" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPC-7C-F3C">
+                                                    <rect key="frame" x="20" y="20" width="207" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="ANF-Ow-3Ja" kind="popoverPresentation" popoverAnchorView="Pl7-1O-GPX" id="BrD-gl-AgG">
+                                                <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
+                                            </segue>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="FqL-ll-bZE">
+                                        <rect key="frame" x="0.0" y="312.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FqL-ll-bZE" id="Csm-85-5Va">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transition Style: Cover Vertical" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qpm-jX-bUW">
+                                                    <rect key="frame" x="20" y="20" width="233" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="gqv-C5-hmY" kind="presentation" id="tEo-za-Cqh"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="ZEz-hi-oFU">
+                                        <rect key="frame" x="0.0" y="379.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZEz-hi-oFU" id="i47-zI-LOs">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transition Style: Flip Horizontal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TZ1-jW-yQN">
+                                                    <rect key="frame" x="20" y="20" width="235" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="eHB-Xy-nrs" kind="presentation" id="NzQ-wL-jDz"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="EMd-iE-IXD">
+                                        <rect key="frame" x="0.0" y="446.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EMd-iE-IXD" id="xa9-CB-oi4">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transition Style: Cross Dissolve" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q4w-Xk-mLA">
+                                                    <rect key="frame" x="20" y="20" width="238" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="TPs-fH-aHe" kind="presentation" id="Nk4-NE-145"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="67" id="bQ1-Xd-lj3">
+                                        <rect key="frame" x="0.0" y="513.5" width="414" height="67"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bQ1-Xd-lj3" id="sDf-Xo-mAt">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="67"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transition Style: Partial Curl" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6P-m0-Tcj">
+                                                    <rect key="frame" x="20" y="20" width="209" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="AXM-Ke-pEy" kind="show" id="viF-eB-hXG"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="pb9-bq-Xnt" id="Jbe-G5-eZz"/>
+                            <outlet property="delegate" destination="pb9-bq-Xnt" id="6fF-O1-OTY"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Test" id="a00-em-SGg"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="96a-e6-Dmg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="71" y="1653"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="r5B-Ac-Z5F">
+            <objects>
+                <viewController modalTransitionStyle="crossDissolve" id="TPs-fH-aHe" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Pst-jM-7Zz">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cross Dissolve" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jeN-nL-LsO">
+                                <rect key="frame" x="111.5" y="403" width="191" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="7s7-pB-eZQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="jeN-nL-LsO" firstAttribute="centerY" secondItem="Pst-jM-7Zz" secondAttribute="centerY" id="3NO-U4-hkD"/>
+                            <constraint firstItem="jeN-nL-LsO" firstAttribute="centerX" secondItem="Pst-jM-7Zz" secondAttribute="centerX" id="GGr-fE-xiY"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="lsS-HK-gup"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ICi-A2-9uB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1483" y="2644"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="6Gy-Iv-3Sp">
+            <objects>
+                <viewController modalTransitionStyle="flipHorizontal" id="eHB-Xy-nrs" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XRL-9n-5MJ">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Flip Horizontal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0FJ-58-dvL">
+                                <rect key="frame" x="115" y="403" width="184.5" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="4y3-Iz-RPs"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="0FJ-58-dvL" firstAttribute="centerY" secondItem="XRL-9n-5MJ" secondAttribute="centerY" id="U7H-TE-WtL"/>
+                            <constraint firstItem="0FJ-58-dvL" firstAttribute="centerX" secondItem="XRL-9n-5MJ" secondAttribute="centerX" id="y3C-uQ-ag3"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="TOn-4b-utm"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aHZ-O8-jjO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2249" y="2478"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="RHZ-1M-kHI">
+            <objects>
+                <viewController id="gqv-C5-hmY" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="cIs-63-Zac">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cover Vertical" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Yc-wM-GWk">
+                                <rect key="frame" x="117" y="403" width="180" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="bnS-5T-48c"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="1Yc-wM-GWk" firstAttribute="centerY" secondItem="cIs-63-Zac" secondAttribute="centerY" id="Sdb-nI-pqC"/>
+                            <constraint firstItem="1Yc-wM-GWk" firstAttribute="centerX" secondItem="cIs-63-Zac" secondAttribute="centerX" id="c5D-S5-aJ4"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ga0-qD-aFg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3005.7971014492755" y="2284.8214285714284"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="63v-gj-4eq">
+            <objects>
+                <viewController id="ANF-Ow-3Ja" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5d2-bD-dua">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Present As Popover" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F1n-cu-CiF">
+                                <rect key="frame" x="81.5" y="403" width="251" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="RCW-zs-Aai"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="F1n-cu-CiF" firstAttribute="centerY" secondItem="5d2-bD-dua" secondAttribute="centerY" id="76h-LU-Yr3"/>
+                            <constraint firstItem="F1n-cu-CiF" firstAttribute="centerX" secondItem="5d2-bD-dua" secondAttribute="centerX" id="7dg-Mo-oTI"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0ys-wR-zaI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3104" y="1547"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="3Wc-io-r5B">
+            <objects>
+                <viewController id="Ydl-NW-a1z" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="y2H-51-Vxz">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Present Modally" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jg5-fl-Vt5">
+                                <rect key="frame" x="103.5" y="403" width="207" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="D6J-JD-FBW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Jg5-fl-Vt5" firstAttribute="centerY" secondItem="y2H-51-Vxz" secondAttribute="centerY" id="4qa-4Z-Y0o"/>
+                            <constraint firstItem="Jg5-fl-Vt5" firstAttribute="centerX" secondItem="y2H-51-Vxz" secondAttribute="centerX" id="pTW-IA-KBA"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="KxA-t8-TY1"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Yhp-4e-8pq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2287" y="1301"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="aFh-fl-KiD">
+            <objects>
+                <viewController id="LNo-ec-s45" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="axw-dM-p5g">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sQy-x5-iWj">
+                                <rect key="frame" x="170.5" y="430" width="73" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="mCC-ej-J9a"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="sQy-x5-iWj" firstAttribute="centerX" secondItem="axw-dM-p5g" secondAttribute="centerX" id="uZ9-QW-4Ux"/>
+                            <constraint firstItem="sQy-x5-iWj" firstAttribute="centerY" secondItem="axw-dM-p5g" secondAttribute="centerY" id="xA0-ZF-ebi"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="fcY-kK-9hu"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6tW-TA-N3K" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="370" y="896"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Nau-H3-XxS">
+            <objects>
+                <viewController id="zP7-hJ-ZFK" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5eZ-Qw-hfC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WmN-1K-d8o">
+                                <rect key="frame" x="130" y="403" width="154" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="WCe-UI-GLw"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="WmN-1K-d8o" firstAttribute="centerX" secondItem="5eZ-Qw-hfC" secondAttribute="centerX" id="0c4-tW-tlV"/>
+                            <constraint firstItem="WmN-1K-d8o" firstAttribute="centerY" secondItem="5eZ-Qw-hfC" secondAttribute="centerY" id="rLd-qg-gt1"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vKO-80-3sI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1249" y="1114"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="h8d-75-ofR">
+            <objects>
+                <navigationController id="PCs-63-X1z" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="D0M-w3-LPz">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="pb9-bq-Xnt" kind="relationship" relationship="rootViewController" id="4CS-lB-Bn4"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yVP-4r-Lwy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-878" y="1653"/>
+        </scene>
         <!--Item 2-->
         <scene sceneID="N35-Un-ltS">
             <objects>
@@ -152,6 +548,34 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ekc-el-hvT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="252" y="-137"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="YHy-3p-0ug">
+            <objects>
+                <viewController modalTransitionStyle="partialCurl" id="AXM-Ke-pEy" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="DA6-fm-iDk">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Partial Curl" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuK-De-DGf">
+                                <rect key="frame" x="136.5" y="430" width="141" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="3nU-fB-iXG"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="EuK-De-DGf" firstAttribute="centerY" secondItem="DA6-fm-iDk" secondAttribute="centerY" id="1qU-JD-09p"/>
+                            <constraint firstItem="EuK-De-DGf" firstAttribute="centerX" secondItem="DA6-fm-iDk" secondAttribute="centerX" id="Nbx-Ja-V1v"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="b96-JH-70E"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="18G-Ew-R4K" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="640.57971014492762" y="2718.75"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -91,11 +91,25 @@
                                     <segue destination="obM-Ks-hqv" kind="show" id="mbK-aY-17Q"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YgL-bv-mT7">
+                                <rect key="frame" x="20" y="20" width="60" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="60" id="1Qf-vi-Si0"/>
+                                </constraints>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="fWP-MA-5AE" eventType="touchUpInside" id="Cu6-fk-pi5"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Zo3-M5-yy8"/>
                         <color key="backgroundColor" red="1" green="0.76244297058229082" blue="0.85208236719575248" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="YgL-bv-mT7" firstAttribute="top" secondItem="Zo3-M5-yy8" secondAttribute="top" constant="20" id="LWA-I9-wgB"/>
                             <constraint firstItem="1J2-Ip-E46" firstAttribute="centerX" secondItem="1zk-pe-4jp" secondAttribute="centerX" id="Or7-Sh-Gi0"/>
+                            <constraint firstItem="YgL-bv-mT7" firstAttribute="leading" secondItem="Zo3-M5-yy8" secondAttribute="leading" constant="20" id="Z1W-FH-pyV"/>
                             <constraint firstItem="1J2-Ip-E46" firstAttribute="centerY" secondItem="1zk-pe-4jp" secondAttribute="centerY" id="eeP-fp-5aa"/>
                         </constraints>
                     </view>

--- a/PhotoFrame/PhotoFrame/MintViewController.swift
+++ b/PhotoFrame/PhotoFrame/MintViewController.swift
@@ -1,0 +1,16 @@
+//
+//  MintViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class MintViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/PhotoFrame/PhotoFrame/MintViewController.swift
+++ b/PhotoFrame/PhotoFrame/MintViewController.swift
@@ -18,7 +18,7 @@ class MintViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(#file, #line, #function, #column)
+        print("MintViewController", #function)
         
 //        self.view.addSubview(closeButton)
 //        // 이렇게 하는 방법은 addSubview의 위치가 상관없고, translatesAutoresizingMaskIntoConstraints는 true여야한다. false이면 위치가 지정이 안돼. 그냥
@@ -45,24 +45,24 @@ class MintViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print(#file, #line, #function, #column)
+        print("MintViewController", #function)
     }
     
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        print(#file, #line, #function, #column)
+        print("MintViewController", #function)
     }
     
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("MintViewController", #function)
     }
     
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("MintViewController", #function)
     }
 }

--- a/PhotoFrame/PhotoFrame/MintViewController.swift
+++ b/PhotoFrame/PhotoFrame/MintViewController.swift
@@ -18,7 +18,7 @@ class MintViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        print(#file, #line, #function, #column)
         
 //        self.view.addSubview(closeButton)
 //        // 이렇게 하는 방법은 addSubview의 위치가 상관없고, translatesAutoresizingMaskIntoConstraints는 true여야한다. false이면 위치가 지정이 안돼. 그냥
@@ -40,5 +40,29 @@ class MintViewController: UIViewController {
         closeButton.setTitle("닫기", for: .normal)
         closeButton.tintColor = .black
         closeButton.addTarget(self, action: #selector(self.closeButtonTouched(_:)), for: .touchUpInside)
+    }
+    
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/MintViewController.swift
+++ b/PhotoFrame/PhotoFrame/MintViewController.swift
@@ -9,8 +9,36 @@ import UIKit
 
 class MintViewController: UIViewController {
 
+    let closeButton = UIButton(type: UIButton.ButtonType.roundedRect) as UIButton
+    
+    @objc func closeButtonTouched(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        
+//        self.view.addSubview(closeButton)
+//        // 이렇게 하는 방법은 addSubview의 위치가 상관없고, translatesAutoresizingMaskIntoConstraints는 true여야한다. false이면 위치가 지정이 안돼. 그냥
+//        self.closeButton.frame = CGRect(x: 20, y: 20, width: 100, height: 45)
+//        self.closeButton.backgroundColor = .white
+//        self.closeButton.setTitle("닫기", for: .normal)
+//        self.closeButton.tintColor = .black
+//        self.closeButton.addTarget(self, action: #selector(self.closeButtonTouched(_:)), for: .touchUpInside)
+        
+        
+        // constraint를 주는 방법은 subView가 반드시 제일 먼저 와야하고, translatesAUtoresizingMaskIntoConstraints는 false여야한다. true이면 안된다.
+        self.view.addSubview(closeButton)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        closeButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor, constant: 150).isActive = true
+        closeButton.widthAnchor.constraint(equalToConstant: 150).isActive = true
+        closeButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        closeButton.backgroundColor = .white
+        closeButton.setTitle("닫기", for: .normal)
+        closeButton.tintColor = .black
+        closeButton.addTarget(self, action: #selector(self.closeButtonTouched(_:)), for: .touchUpInside)
     }
 }

--- a/PhotoFrame/PhotoFrame/PinkViewController.swift
+++ b/PhotoFrame/PhotoFrame/PinkViewController.swift
@@ -1,0 +1,29 @@
+//
+//  PinkViewController.swift
+//  PhotoFrame
+//
+//  Created by 안상희 on 2022/02/18.
+//
+
+import UIKit
+
+class PinkViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/PhotoFrame/PhotoFrame/PinkViewController.swift
+++ b/PhotoFrame/PhotoFrame/PinkViewController.swift
@@ -2,28 +2,20 @@
 //  PinkViewController.swift
 //  PhotoFrame
 //
-//  Created by 안상희 on 2022/02/18.
+//  Created by Selina on 2022/02/18.
 //
 
 import UIKit
 
 class PinkViewController: UIViewController {
 
+    @IBAction func closeButtonTouched(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/PhotoFrame/PhotoFrame/PinkViewController.swift
+++ b/PhotoFrame/PhotoFrame/PinkViewController.swift
@@ -16,6 +16,30 @@ class PinkViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/PinkViewController.swift
+++ b/PhotoFrame/PhotoFrame/PinkViewController.swift
@@ -16,30 +16,30 @@ class PinkViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(#file, #line, #function, #column)
+        print("PinkViewController", #function)
     }
     
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print(#file, #line, #function, #column)
+        print("PinkViewController", #function)
     }
     
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        print(#file, #line, #function, #column)
+        print("PinkViewController", #function)
     }
     
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("PinkViewController", #function)
     }
     
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("PinkViewController", #function)
     }
 }

--- a/PhotoFrame/PhotoFrame/SegueModallyViewController.swift
+++ b/PhotoFrame/PhotoFrame/SegueModallyViewController.swift
@@ -1,0 +1,39 @@
+//
+//  SegueModallyViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class SegueModallyViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("SegueModallyViewController", #function)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print("SegueModallyViewController", #function)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print("SegueModallyViewController", #function)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print("SegueModallyViewController", #function)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print("SegueModallyViewController", #function)
+    }
+}

--- a/PhotoFrame/PhotoFrame/SeguePopoverViewController.swift
+++ b/PhotoFrame/PhotoFrame/SeguePopoverViewController.swift
@@ -1,0 +1,39 @@
+//
+//  SeguePopoverViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class SeguePopoverViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("SeguePopoverViewController", #function)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print("SeguePopoverViewController", #function)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print("SeguePopoverViewController", #function)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print("SeguePopoverViewController", #function)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print("SeguePopoverViewController", #function)
+    }
+}

--- a/PhotoFrame/PhotoFrame/SegueShowDetailViewController.swift
+++ b/PhotoFrame/PhotoFrame/SegueShowDetailViewController.swift
@@ -1,0 +1,39 @@
+//
+//  SegueShowDetailViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class SegueShowDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("SegueShowDetailViewController", #function)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print("SegueShowDetailViewController", #function)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print("SegueShowDetailViewController", #function)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print("SegueShowDetailViewController", #function)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print("SegueShowDetailViewController", #function)
+    }
+}

--- a/PhotoFrame/PhotoFrame/SegueShowViewController.swift
+++ b/PhotoFrame/PhotoFrame/SegueShowViewController.swift
@@ -1,0 +1,39 @@
+//
+//  SegueShowViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class SegueShowViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("SegueShowViewController", #function)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print("SegueShowViewController", #function)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print("SegueShowViewController", #function)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print("SegueShowViewController", #function)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print("SegueShowViewController", #function)
+    }
+}

--- a/PhotoFrame/PhotoFrame/TestTableViewController.swift
+++ b/PhotoFrame/PhotoFrame/TestTableViewController.swift
@@ -1,0 +1,39 @@
+//
+//  TestTableViewController.swift
+//  PhotoFrame
+//
+//  Created by Selina on 2022/02/18.
+//
+
+import UIKit
+
+class TestTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("TestTableViewController", #function)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print("TestTableViewController", #function)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print("TestTableViewController", #function)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print("TestTableViewController", #function)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print("TestTableViewController", #function)
+    }
+}

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -38,7 +38,7 @@ class ViewController: UIViewController {
         self.firstLabel.textColor = #colorLiteral(red: 0.8549019694, green: 0.250980407, blue: 0.4784313738, alpha: 1)
         self.firstLabel.backgroundColor = UIColor(red: 250 / 255.0, green: 197 / 255.0, blue: 210 / 255.0, alpha: 1)
         self.firstLabel.backgroundColor = UIColor(cgColor: CGColor(red: 250 / 255.0, green: 197 / 255.0, blue: 210 / 255.0, alpha: 1))
-        self.firstLabel.font = UIFont.boldSystemFont(ofSize: 40)
+        self.firstLabel.font = UIFont.boldSystemFont(ofSize: 35)
         
         // 세로 위치 중 가운데로 배치
         self.firstLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -23,7 +23,8 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        print(#file, #line, #function, #column)
+        
         // subView 추가
         self.view.addSubview(firstLabel)
         self.view.addSubview(firstDescription)
@@ -51,5 +52,29 @@ class ViewController: UIViewController {
         self.firstDescription.font = UIFont.systemFont(ofSize: 15)
         self.firstDescription.topAnchor.constraint(equalTo: firstLabel.topAnchor, constant: 60).isActive = true
         self.firstDescription.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    }
+    
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/ViewController.swift
+++ b/PhotoFrame/PhotoFrame/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(#file, #line, #function, #column)
+        print("FirstViewController", #function)
         
         // subView 추가
         self.view.addSubview(firstLabel)
@@ -57,24 +57,24 @@ class ViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print(#file, #line, #function, #column)
+        print("FirstViewController", #function)
     }
     
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        print(#file, #line, #function, #column)
+        print("FirstViewController", #function)
     }
     
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("FirstViewController", #function)
     }
     
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        print(#file, #line, #function, #column)
+        print("FirstViewController", #function)
     }
 }


### PR DESCRIPTION
## 💻 작업 목록

- [x] 새로운 뷰 컨트롤러 2개 추가
- [x] 위에서 만든 뷰 컨트롤러에 닫기 버튼 추가 후 닫기 기능 구현
- [x] ViewController의 라이프 사이클 학습 및 실습
- [ ] 두번째 뷰컨트롤러에서 Segue를 제거하고 다음 화면을 보여줄 때 코드로 보여주는 방법 적용하고 학습
- [ ] Step5 README 작성하기


## 📱 실행 화면

![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/95578975/154621684-9a04544e-9281-4036-905d-da65eb817411.gif)

- FirstViewController -> PinkViewController, PinkViewController -> MintViewController로 넘어갈 때 viewWillDisppear, viewDidDisappear 메소드가 호출되지 않는다. 
- 새로운 뷰가 나타날 때, 기존의 뷰가 사라지는 것이 아니라 그 위에 새로운 뷰가 올라가는 것이기 때문에 viewWillDisappear, viewDidDisappear 메소드는 호출되지 않는다. 자세히 보면 위에 기존의 뷰가 보이는 것을 확인할 수 있다.



## 🤔 고민과 해결

### 1️⃣  Segue & Transition Style 

Presentation은 모두 Automatic으로 바꾸고, Segue와 Transition Style을 테스트해보았습니다. 

- Segue - Popover의 경우, 아이패드에서만 차이점을 알 수 있었습니다. 
- Transition Style은 모두 Segue를 Present Modally로 연결하였습니다. FullScreen일 경우, Transition Style에는 변화가 없었습니다.
  - Transition Style - Partial Curl의 경우, Segue를 Present Modally로 설정하면 "Thread 1: "Application tried to present UIModalTransitionStylePartialCurl to or from non-fullscreen view controller <PhotoFrame.TestTableViewController: 0x144d143a0>."와 같은 오류 메시지를 확인할 수 있었습니다.
  - [애플 공식 문서](https://developer.apple.com/documentation/uikit/uimodaltransitionstyle/uimodaltransitionstylepartialcurl?language=objc)에서 Partial Curl 스타일은 상위 뷰컨트롤러가 FullScreen 뷰를 표시하고 [UIModalPresentationFullScreen](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc) 모달 프레젠테이션 스타일을 사용하는 경우에만 지원한다고 합니다. 그 외의 form factor를 사용하려고 하면 예외가 트리거됩니다.
- Transition Style - Partial Curl의 경우, Segue를 Present Modally로 하면 오류가 발생하기 때문에 Show로 해야합니다.

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/95578975/154633705-d317c933-06f5-45e4-ba11-bcae17f66054.gif)



### 2️⃣  viewWillDisappear, viewDidDisappear 출력해보기

viewWillDisappear, viewDidDisappear 출력을 확인하기 위해 TableViewController와 Navigation Controller를 추가하여 테스트해보았습니다.

Show Detail, Present Modally과 Present As Popover 방식은 앞과 똑같이 두 함수가 호출되지 않았고, Show 방식은 앞의 Modal 방식과 달리 화면 전체가 새로운 뷰로 꽉 찬 것을 확인할 수 있었습니다. 그리고 viewWillDisappear, viewDidDisappear 함수의 호출도 확인할 수 있었습니다.

![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/95578975/154637764-0be225fe-4a86-4b19-9e65-2eb0e8bc1464.gif)

## ✏️ 추가 학습 거리

### ViewController의 라이프 사이클

- **func viewDidLoad()** : 뷰 계층이 **메모리에 로드된 직후** 호출. 

- **func viewWillAppear(_ animated: Bool)** : 뷰가 뷰 계층에 추가되고 **화면에 표시되기 직전에** 호출.

- **func viewDidAppear(_ animated: Bool)** : 뷰가 뷰 계층에 추가되어 **화면이 표시되면** 호출.

- **func viewWillDisappear(_ animated: Bool)** : 뷰가 뷰 계층에서 사라지기 직전에 호출.

- **func viewDidDisappear(_ animated: Bool)** : 뷰가 뷰 계층에서 **사라진 후** 호출.



### YellowViewController에서 Segue를 제거하고 다음 화면을 보여줄 때 코드로 보여주는 방법

- 다음 PR 때 진행 예정입니다..!



## ❓ 질문 거리

- 제가 앞에 테스트한 것처럼 화면이 Full Screen으로 대체되는 경우에만 viewWillDisappear, viewDidDisappear이 호출되는 것이 맞나요?

## 💡 학습 키워드

- ViewController
- LifeCycle
- [ViewController LifeCycle](https://medium.com/good-morning-swift/ios-view-controller-life-cycle-2a0f02e74ff5)
- [UIModalTransitionStyle](https://developer.apple.com/documentation/uikit/uimodaltransitionstyle?language=objc)