### PR TITLE
[Alex] Step 8 사진 앨범 선택하기

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 				DEVELOPMENT_TEAM = FCQD35AW5P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoFrame/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "사진 촬영을 위해 카메라 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -368,6 +369,7 @@
 				DEVELOPMENT_TEAM = FCQD35AW5P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoFrame/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "사진 촬영을 위해 카메라 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/PhotoFrame/PhotoFrame/AppDelegate.swift
+++ b/PhotoFrame/PhotoFrame/AppDelegate.swift
@@ -11,26 +11,16 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
+    
+    
 }
 

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -314,55 +314,123 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="49" translatesAutoresizingMaskIntoConstraints="NO" id="Azo-Pf-xgP">
-                                <rect key="frame" x="50" y="205" width="314" height="486"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Azo-Pf-xgP">
+                                <rect key="frame" x="87" y="226.5" width="240" height="443"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JDF-ZG-0iW">
-                                        <rect key="frame" x="0.0" y="0.0" width="314" height="314"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="redraw" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="01" translatesAutoresizingMaskIntoConstraints="NO" id="ASH-p5-XKv">
-                                                <rect key="frame" x="36" y="36" width="242" height="242"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="01" translatesAutoresizingMaskIntoConstraints="NO" id="ASH-p5-XKv">
+                                                <rect key="frame" x="14" y="0.0" width="212" height="212.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="ASH-p5-XKv" secondAttribute="height" multiplier="1:1" id="2zk-yH-Ebl"/>
+                                                </constraints>
                                             </imageView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="photoframe-border" translatesAutoresizingMaskIntoConstraints="NO" id="afk-pC-5qW" userLabel="PhotoFrame">
-                                                <rect key="frame" x="0.0" y="0.0" width="314" height="314"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="240" id="XMC-Hn-HAO"/>
+                                                    <constraint firstAttribute="width" secondItem="afk-pC-5qW" secondAttribute="height" multiplier="1:1" id="d43-dJ-KbW"/>
+                                                </constraints>
                                             </imageView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="314" id="1dR-WT-VB9"/>
-                                            <constraint firstAttribute="bottom" secondItem="afk-pC-5qW" secondAttribute="bottom" id="52O-w6-2RX"/>
-                                            <constraint firstItem="afk-pC-5qW" firstAttribute="top" secondItem="JDF-ZG-0iW" secondAttribute="top" id="6lV-8F-V3a"/>
-                                            <constraint firstAttribute="bottom" secondItem="ASH-p5-XKv" secondAttribute="bottom" constant="36" id="OAZ-fX-HBx"/>
-                                            <constraint firstAttribute="height" constant="314" id="XLD-qK-K2t"/>
-                                            <constraint firstItem="ASH-p5-XKv" firstAttribute="leading" secondItem="JDF-ZG-0iW" secondAttribute="leading" constant="36" id="ZGk-AO-Fv6"/>
-                                            <constraint firstAttribute="trailing" secondItem="ASH-p5-XKv" secondAttribute="trailing" constant="36" id="dp4-aD-TAE"/>
-                                            <constraint firstItem="ASH-p5-XKv" firstAttribute="top" secondItem="JDF-ZG-0iW" secondAttribute="top" constant="36" id="f26-1e-ysG"/>
-                                            <constraint firstAttribute="trailing" secondItem="afk-pC-5qW" secondAttribute="trailing" id="fXp-qq-t2S"/>
-                                            <constraint firstItem="afk-pC-5qW" firstAttribute="leading" secondItem="JDF-ZG-0iW" secondAttribute="leading" id="v4l-8D-o8A"/>
+                                            <constraint firstItem="afk-pC-5qW" firstAttribute="top" secondItem="ASH-p5-XKv" secondAttribute="top" id="08x-cn-riM"/>
+                                            <constraint firstItem="afk-pC-5qW" firstAttribute="centerX" secondItem="ASH-p5-XKv" secondAttribute="centerX" id="0Tr-R4-HeI"/>
+                                            <constraint firstItem="afk-pC-5qW" firstAttribute="leading" secondItem="JDF-ZG-0iW" secondAttribute="leading" id="1K1-pj-GZG"/>
+                                            <constraint firstItem="afk-pC-5qW" firstAttribute="bottom" secondItem="ASH-p5-XKv" secondAttribute="bottom" multiplier="1.13" id="Kzv-rA-8CE"/>
+                                            <constraint firstAttribute="bottom" secondItem="afk-pC-5qW" secondAttribute="bottom" id="dlp-DL-OLY"/>
+                                            <constraint firstAttribute="trailing" secondItem="afk-pC-5qW" secondAttribute="trailing" id="feh-Xk-GAG"/>
+                                            <constraint firstItem="afk-pC-5qW" firstAttribute="top" secondItem="JDF-ZG-0iW" secondAttribute="top" id="sAf-xM-ppO"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Photo Album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QFP-bx-Ep5">
-                                        <rect key="frame" x="58" y="363" width="198.5" height="43"/>
+                                        <rect key="frame" x="21" y="270" width="198.5" height="43"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O4G-nz-GQn">
-                                        <rect key="frame" x="52.5" y="455" width="209" height="31"/>
+                                        <rect key="frame" x="10.5" y="343" width="219" height="100"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9fg-XM-Geu">
-                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="31"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="다른 사진 보기"/>
-                                                <connections>
-                                                    <action selector="selectButtonTouched:" destination="OeU-15-MY6" eventType="touchUpInside" id="aF1-Ux-NtA"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ux3-SV-BY3">
-                                                <rect key="frame" x="104.5" y="0.0" width="104.5" height="31"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="다음"/>
-                                            </button>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4id-m2-SMH">
+                                                <rect key="frame" x="0.0" y="0.0" width="219" height="100"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GN5-1M-7Kq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="219" height="40"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9fg-XM-Geu" customClass="DesignableButton" customModule="PhotoFrame" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="40"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="40" id="dnL-Yy-wF8"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Button"/>
+                                                                <buttonConfiguration key="configuration" style="plain" title="다른 사진 보기"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                        <color key="value" systemColor="tintColor"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                                        <real key="value" value="1"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                        <real key="value" value="5"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="selectButtonTouched:" destination="OeU-15-MY6" eventType="touchUpInside" id="aF1-Ux-NtA"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ux3-SV-BY3" customClass="DesignableButton" customModule="PhotoFrame" customModuleProvider="target">
+                                                                <rect key="frame" x="114.5" y="0.0" width="104.5" height="40"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="40" id="d26-eo-yzo"/>
+                                                                </constraints>
+                                                                <color key="tintColor" systemColor="systemGreenColor"/>
+                                                                <state key="normal" title="Button"/>
+                                                                <buttonConfiguration key="configuration" style="plain" title="다음"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                        <color key="value" systemColor="systemGreenColor"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                                        <real key="value" value="1"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                        <real key="value" value="5"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k47-dE-gek" customClass="DesignableButton" customModule="PhotoFrame" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="50" width="219" height="50"/>
+                                                        <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="50" id="eoi-7t-mwD"/>
+                                                        </constraints>
+                                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="사진 가져오기"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="disabled" value="NO"/>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                                <real key="value" value="0.0"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                <real key="value" value="5"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="selectPhoto:" destination="OeU-15-MY6" eventType="touchUpInside" id="PMg-UC-Ynw"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
@@ -372,6 +440,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Azo-Pf-xgP" firstAttribute="centerY" secondItem="nWM-qV-tNX" secondAttribute="centerY" id="NE7-SB-Bkc"/>
+                            <constraint firstItem="av8-0K-Bc8" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Azo-Pf-xgP" secondAttribute="bottom" constant="20" id="nZK-4q-HDn"/>
                             <constraint firstItem="Azo-Pf-xgP" firstAttribute="centerX" secondItem="nWM-qV-tNX" secondAttribute="centerX" id="p6A-vs-7pX"/>
                         </constraints>
                     </view>
@@ -514,6 +583,15 @@
         </scene>
     </scenes>
     <designables>
+        <designable name="9fg-XM-Geu">
+            <size key="intrinsicContentSize" width="104.5" height="31"/>
+        </designable>
+        <designable name="Ux3-SV-BY3">
+            <size key="intrinsicContentSize" width="48.5" height="31"/>
+        </designable>
+        <designable name="k47-dE-gek">
+            <size key="intrinsicContentSize" width="100.5" height="31"/>
+        </designable>
         <designable name="xaK-1S-cG1">
             <size key="intrinsicContentSize" width="221" height="41.5"/>
         </designable>
@@ -541,6 +619,9 @@
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="tintColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -260,21 +260,30 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="xe2-9p-svk">
-                                <rect key="frame" x="125" y="432.5" width="164" height="31"/>
+                                <rect key="frame" x="6.5" y="432.5" width="401" height="31"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="18a-Ac-S6b">
-                                        <rect key="frame" x="0.0" y="0.0" width="72.5" height="31"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="121" height="31"/>
                                         <color key="tintColor" red="1" green="1" blue="0.89019607840000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="처음으로"/>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lfq-l0-b11">
-                                        <rect key="frame" x="91.5" y="0.0" width="72.5" height="31"/>
+                                        <rect key="frame" x="140" y="0.0" width="121" height="31"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="이전으로"/>
                                         <connections>
                                             <action selector="closeButtonTouched:" destination="Z29-XM-XrQ" eventType="touchUpInside" id="Qe3-vx-mzd"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwx-Oa-rrj">
+                                        <rect key="frame" x="280" y="0.0" width="121" height="31"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Go somewhere"/>
+                                        <connections>
+                                            <segue destination="0HV-rF-61C" kind="unwind" unwindAction="unwindWithSegue:" id="grM-hw-L6e"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -289,10 +298,11 @@
                     </view>
                     <navigationItem key="navigationItem" id="Lky-BC-sxa"/>
                     <connections>
-                        <outlet property="homeButton" destination="18a-Ac-S6b" id="hev-Hb-Jf0"/>
+                        <outlet property="homeButton" destination="18a-Ac-S6b" id="mzD-iN-vaX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="agv-Xu-7JR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="0HV-rF-61C" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="3357.971014492754" y="-152.00892857142856"/>
         </scene>
@@ -417,10 +427,10 @@
             </objects>
             <point key="canvasLocation" x="1630" y="580"/>
         </scene>
-        <!--Green View Controller-->
+        <!--Green-->
         <scene sceneID="0Ex-mY-WYf">
             <objects>
-                <viewController storyboardIdentifier="GreenViewController" id="uUC-Jt-yJe" customClass="GreenViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GreenViewController" id="uUC-Jt-yJe" userLabel="Green" customClass="GreenViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Nld-nI-1AR">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -432,6 +442,9 @@
                                         <rect key="frame" x="0.0" y="0.0" width="72.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="처음으로"/>
+                                        <connections>
+                                            <segue destination="Eld-hU-1hq" kind="unwind" identifier="test" unwindAction="unwindWithSegue:" id="4aX-ye-kyQ"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PTy-wP-HSA">
                                         <rect key="frame" x="82.5" y="0.0" width="72.5" height="31"/>
@@ -452,7 +465,6 @@
                     <connections>
                         <outlet property="closeButton" destination="PTy-wP-HSA" id="0um-d3-RR8"/>
                         <outlet property="homeButton" destination="Oyy-t2-GdP" id="Y3W-a4-xAo"/>
-                        <segue destination="Eld-hU-1hq" kind="unwind" identifier="goHome" unwindAction="unwindWithSegue:" id="pfa-go-H4T"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ntp-uG-tZA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/PhotoFrame/PhotoFrame/Components/DesignableButton.swift
+++ b/PhotoFrame/PhotoFrame/Components/DesignableButton.swift
@@ -40,10 +40,4 @@ class DesignableButton: UIButton {
         }
     }
     
-    @IBInspectable
-    var enableShadow: Bool = false {
-        didSet {
-            self.layer.masksToBounds = enableShadow
-        }
-    }
 }

--- a/PhotoFrame/PhotoFrame/FirstViewController.swift
+++ b/PhotoFrame/PhotoFrame/FirstViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class FirstViewController: UIViewController {
+    
     // MARK: - Properties
     @IBOutlet weak var photoLabel: UILabel!
     

--- a/PhotoFrame/PhotoFrame/GreenViewController.swift
+++ b/PhotoFrame/PhotoFrame/GreenViewController.swift
@@ -47,16 +47,11 @@ class GreenViewController: UIViewController {
         self.closeButton.addTarget(self, action: #selector(self.closeScene), for: .touchUpInside)
     }
     
-    @objc func backToHome() {
-        print("Button")
-    }
-    
     @objc func closeScene() {
         self.dismiss(animated: true, completion: nil)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        print("Prepare to peform Segue")
         let destinationVC = segue.destination as! SecondViewController
         destinationVC.photoImageView.image = UIImage(named: "01.jpg")
     }

--- a/PhotoFrame/PhotoFrame/GreenViewController.swift
+++ b/PhotoFrame/PhotoFrame/GreenViewController.swift
@@ -13,6 +13,8 @@ class GreenViewController: UIViewController {
     @IBOutlet weak var homeButton: UIButton!
     @IBOutlet weak var closeButton: UIButton!
     
+    var backgroundColor = UIColor.green
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,15 +44,20 @@ class GreenViewController: UIViewController {
     
     // MARK: - Methods
     func configureButtons() {
-        self.homeButton.addTarget(self, action: #selector(self.backToHome), for: .touchUpInside)
         self.closeButton.addTarget(self, action: #selector(self.closeScene), for: .touchUpInside)
     }
     
     @objc func backToHome() {
-        self.performSegue(withIdentifier: "goHome", sender: self)   
+        print("Button")
     }
     
     @objc func closeScene() {
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        print("Prepare to peform Segue")
+        let destinationVC = segue.destination as! SecondViewController
+        destinationVC.nickName = "Dog"
     }
 }

--- a/PhotoFrame/PhotoFrame/GreenViewController.swift
+++ b/PhotoFrame/PhotoFrame/GreenViewController.swift
@@ -58,6 +58,6 @@ class GreenViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         print("Prepare to peform Segue")
         let destinationVC = segue.destination as! SecondViewController
-        destinationVC.nickName = "Dog"
+        destinationVC.photoImageView.image = UIImage(named: "01.jpg")
     }
 }

--- a/PhotoFrame/PhotoFrame/Info.plist
+++ b/PhotoFrame/PhotoFrame/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key></key>
+	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/PhotoFrame/PhotoFrame/Info.plist
+++ b/PhotoFrame/PhotoFrame/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
-	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/PhotoFrame/PhotoFrame/SceneDelegate.swift
+++ b/PhotoFrame/PhotoFrame/SceneDelegate.swift
@@ -13,40 +13,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
-
+    
+    
 }
 

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -14,7 +14,6 @@ class SecondViewController: UIViewController {
     // MARK: - Properties
     @IBOutlet weak var photoImageView: UIImageView!
     @IBOutlet weak var nextButton: UIButton!
-    var nickName = "Cat"
     
     // MARK: - LifeCycle
     override func viewDidLoad() {
@@ -47,9 +46,13 @@ class SecondViewController: UIViewController {
     }
     
     // MARK: - Methods
-    func configureImagePickerController() {
-        self.imagePickerController.delegate = self
-        self.imagePickerController.allowsEditing = true
+    @IBAction func unwind(segue : UIStoryboardSegue) {
+        self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
+    }
+    
+    @objc func presentScene() {
+        guard let vc = storyboard?.instantiateViewController(withIdentifier: "BlueViewController") else { return }
+        self.present(vc, animated: true, completion: nil)
     }
     
     @IBAction func selectButtonTouched(_ sender: Any) {
@@ -59,6 +62,11 @@ class SecondViewController: UIViewController {
     
     @IBAction func selectPhoto(_ sender: Any) {
         self.presentActionSheet()
+    }
+    
+    func configureImagePickerController() {
+        self.imagePickerController.delegate = self
+        self.imagePickerController.allowsEditing = true
     }
     
     func createAction(for type: UIImagePickerController.SourceType, title: String, style: UIAlertAction.Style? = .default) -> UIAlertAction? {
@@ -92,15 +100,16 @@ class SecondViewController: UIViewController {
         self.present(alertController, animated: true, completion: nil)
     }
     
-    @IBAction func unwind(segue : UIStoryboardSegue) {
-        print("Unwind Action")
-        self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
+    func alert(message title: String, with description: String) {
+        let alertController = UIAlertController(title: title, message: description, preferredStyle: .alert)
+        
+        alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
+            self.dismiss(animated: true, completion: nil)
+        }))
+        
+        self.present(alertController, animated: true, completion: nil)
     }
     
-    @objc func presentScene() {
-        guard let vc = storyboard?.instantiateViewController(withIdentifier: "BlueViewController") else { return }
-        self.present(vc, animated: true, completion: nil)
-    }
 }
 
 extension SecondViewController: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
@@ -108,6 +117,7 @@ extension SecondViewController: UINavigationControllerDelegate, UIImagePickerCon
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard let image = info[.editedImage] as? UIImage else {
             self.dismiss(animated: true, completion: nil)
+            self.alert(message: "사진 불러오기 실패", with: "유효한 이미지가 아닙니다.")
             return
         }
         
@@ -116,7 +126,7 @@ extension SecondViewController: UINavigationControllerDelegate, UIImagePickerCon
     }
     
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        print("Cancel")
         self.dismiss(animated: true, completion: nil)
+        self.alert(message: "사진 불러오기 취소", with: "사진 불러오기를 취소하였습니다.")
     }
 }

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -6,8 +6,10 @@
 //
 
 import UIKit
+import AVFoundation
 
-class SecondViewController: UIViewController, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+class SecondViewController: UIViewController {
+    let imagePickerController = UIImagePickerController()
 
     // MARK: - Properties
     @IBOutlet weak var photoImageView: UIImageView!
@@ -19,6 +21,8 @@ class SecondViewController: UIViewController, UINavigationControllerDelegate, UI
         super.viewDidLoad()
         self.photoImageView.image = UIImage(named: "01.jpg")
         self.nextButton.addTarget(self, action: #selector(self.presentScene), for: .touchUpInside)
+        self.configureImagePickerController()
+        
         print("Secnd Tab View")
     }
     
@@ -43,9 +47,49 @@ class SecondViewController: UIViewController, UINavigationControllerDelegate, UI
     }
     
     // MARK: - Methods
+    func configureImagePickerController() {
+        self.imagePickerController.delegate = self
+        self.imagePickerController.allowsEditing = true
+    }
+    
     @IBAction func selectButtonTouched(_ sender: Any) {
-        let num = Int.random(in: 0...22)
-        self.photoImageView.image = UIImage(named: String(format: "%.2d.jpg", num))
+        let number = Int.random(in: 0...22)
+        self.photoImageView.image = UIImage(named: String(format: "%.2d.jpg", number))
+    }
+    
+    @IBAction func selectPhoto(_ sender: Any) {
+        self.presentActionSheet()
+    }
+    
+    func createAction(for type: UIImagePickerController.SourceType, title: String, style: UIAlertAction.Style? = .default) -> UIAlertAction? {
+        guard UIImagePickerController.isSourceTypeAvailable(type) else {
+            return nil
+        }
+        
+        let action = UIAlertAction(title: title, style: .default) { action in
+            self.imagePickerController.sourceType = type
+            self.present(self.imagePickerController, animated: true, completion: nil)
+        }
+        
+        return action
+    }
+    
+    func presentActionSheet() {
+        let alertController = UIAlertController(title: "옵션을 선택해주세요", message: "사진을 촬영하거나 불러올 수 있습니다.", preferredStyle: .actionSheet)
+        
+        if let action = self.createAction(for: .camera, title: "카메라") {
+            alertController.addAction(action)
+        }
+        
+        if let action = self.createAction(for: .photoLibrary, title: "앨범") {
+            alertController.addAction(action)
+        }
+        
+        alertController.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { action in
+            self.dismiss(animated: true, completion: nil)
+        }))
+
+        self.present(alertController, animated: true, completion: nil)
     }
     
     @IBAction func unwind(segue : UIStoryboardSegue) {
@@ -56,5 +100,23 @@ class SecondViewController: UIViewController, UINavigationControllerDelegate, UI
     @objc func presentScene() {
         guard let vc = storyboard?.instantiateViewController(withIdentifier: "BlueViewController") else { return }
         self.present(vc, animated: true, completion: nil)
+    }
+}
+
+extension SecondViewController: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        guard let image = info[.editedImage] as? UIImage else {
+            self.dismiss(animated: true, completion: nil)
+            return
+        }
+        
+        self.photoImageView.image = image
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        print("Cancel")
+        self.dismiss(animated: true, completion: nil)
     }
 }

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -62,7 +62,6 @@ class SecondViewController: UIViewController {
         self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
     }
     
-    
     @IBAction func selectButtonTouched(_ sender: Any) {
         let number = Int.random(in: 0...22)
         self.photoImageView.image = UIImage(named: String(format: "%.2d.jpg", number))

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 
 class SecondViewController: UIViewController {
     let imagePickerController = UIImagePickerController()
-
+    
     // MARK: - Properties
     @IBOutlet weak var photoImageView: UIImageView!
     @IBOutlet weak var nextButton: UIButton!
@@ -45,15 +45,23 @@ class SecondViewController: UIViewController {
         print("Secnd Tab View", #function)
     }
     
-    // MARK: - Methods
-    @IBAction func unwind(segue : UIStoryboardSegue) {
-        self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
+    // MARK: - Configurations
+    func configureImagePickerController() {
+        self.imagePickerController.delegate = self
+        self.imagePickerController.allowsEditing = true
     }
     
+    // MARK: - Segue
     @objc func presentScene() {
         guard let vc = storyboard?.instantiateViewController(withIdentifier: "BlueViewController") else { return }
         self.present(vc, animated: true, completion: nil)
     }
+    
+    // MARK: - IBActions
+    @IBAction func unwind(segue : UIStoryboardSegue) {
+        self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
+    }
+    
     
     @IBAction func selectButtonTouched(_ sender: Any) {
         let number = Int.random(in: 0...22)
@@ -64,9 +72,85 @@ class SecondViewController: UIViewController {
         self.presentActionSheet()
     }
     
-    func configureImagePickerController() {
-        self.imagePickerController.delegate = self
-        self.imagePickerController.allowsEditing = true
+    // MARK: - Permision related methods
+    func requestPermission(for type: AVMediaType) {
+        switch AVCaptureDevice.authorizationStatus(for: type) {
+        case .authorized:
+            self.handlePersmissionGranted()
+        case .notDetermined:
+            self.requestPersmission(for: type)
+        case .denied:
+            self.handlePermissionDenied()
+            return
+        case .restricted:
+            self.handlePermission()
+            return
+        @unknown default:
+            self.handlePermission()
+        }
+    }
+    
+    func handlePersmissionGranted() {
+        self.imagePickerController.sourceType = .camera
+        self.present(self.imagePickerController, animated: true, completion: nil)
+    }
+    
+    func requestPersmission(for type: AVMediaType) {
+        AVCaptureDevice.requestAccess(for: type) { granted in
+            if granted {
+                self.handlePersmissionGranted()
+            } else {
+                self.handlePermissionDenied()
+            }
+        }
+    }
+    
+    func handlePermissionDenied() {
+        let alertController = UIAlertController(title: "카메라 접근 권한 필요", message: "Setting 으로 이동해 카메라 접근 권한을 동의해주세요.", preferredStyle: .alert)
+        
+        alertController.addAction(UIAlertAction(title: "취소", style: .default))
+        alertController.addAction(UIAlertAction(title: "이동", style: .default, handler: { action in
+            self.moveToSettingForPermission()
+        }))
+        
+        self.present(alertController, animated: true, completion: nil)
+    }
+    
+    func handlePermission() {
+        self.alert(message: "카메라 접근 권한", with: "카메라 기능이 제한된 기기입니다.")
+    }
+    
+    func moveToSettingForPermission() {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else { return }
+        
+        if UIApplication.shared.canOpenURL(settingsUrl) {
+            UIApplication.shared.open(settingsUrl)
+        }
+    }
+    
+    // MARK: - Other methods
+    func presentActionSheet() {
+        let alertController = UIAlertController(title: "옵션을 선택해주세요", message: "사진을 촬영하거나 불러올 수 있습니다.", preferredStyle: .actionSheet)
+        
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            let action = UIAlertAction(title: "카메라", style: .default) { action in
+                self.requestPermission(for: .video)
+            }
+            
+            alertController.addAction(action)
+        }
+        
+        if let action = self.createAction(for: .photoLibrary, title: "포토 라이브러리") {
+            alertController.addAction(action)
+        }
+        
+        if let action = self.createAction(for: .savedPhotosAlbum, title: "포토 앨범") {
+            alertController.addAction(action)
+        }
+        
+        alertController.addAction(UIAlertAction(title: "취소", style: .cancel))
+        
+        self.present(alertController, animated: true, completion: nil)
     }
     
     func createAction(for type: UIImagePickerController.SourceType, title: String, style: UIAlertAction.Style? = .default) -> UIAlertAction? {
@@ -82,31 +166,9 @@ class SecondViewController: UIViewController {
         return action
     }
     
-    func presentActionSheet() {
-        let alertController = UIAlertController(title: "옵션을 선택해주세요", message: "사진을 촬영하거나 불러올 수 있습니다.", preferredStyle: .actionSheet)
-        
-        if let action = self.createAction(for: .camera, title: "카메라") {
-            alertController.addAction(action)
-        }
-        
-        if let action = self.createAction(for: .photoLibrary, title: "앨범") {
-            alertController.addAction(action)
-        }
-        
-        alertController.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { action in
-            self.dismiss(animated: true, completion: nil)
-        }))
-
-        self.present(alertController, animated: true, completion: nil)
-    }
-    
     func alert(message title: String, with description: String) {
         let alertController = UIAlertController(title: title, message: description, preferredStyle: .alert)
-        
-        alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
-            self.dismiss(animated: true, completion: nil)
-        }))
-        
+        alertController.addAction(UIAlertAction(title: "확인", style: .default))
         self.present(alertController, animated: true, completion: nil)
     }
     

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -12,6 +12,7 @@ class SecondViewController: UIViewController, UINavigationControllerDelegate, UI
     // MARK: - Properties
     @IBOutlet weak var photoImageView: UIImageView!
     @IBOutlet weak var nextButton: UIButton!
+    var nickName = "Cat"
     
     // MARK: - LifeCycle
     override func viewDidLoad() {
@@ -47,7 +48,10 @@ class SecondViewController: UIViewController, UINavigationControllerDelegate, UI
         self.photoImageView.image = UIImage(named: String(format: "%.2d.jpg", num))
     }
     
-    @IBAction func unwind(segue : UIStoryboardSegue) {}
+    @IBAction func unwind(segue : UIStoryboardSegue) {
+        print("Unwind Action")
+        self.view.backgroundColor = (segue.source as! GreenViewController).backgroundColor
+    }
     
     @objc func presentScene() {
         guard let vc = storyboard?.instantiateViewController(withIdentifier: "BlueViewController") else { return }

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -11,7 +11,7 @@ class YellowViewController: UIViewController {
     
     // MARK: - Properties
     @IBOutlet weak var nextButton: UIButton!
-
+    
     // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
### :pencil2: 작업목록

- [x] 사진 가져오기 버튼 추가
- [x] ActionSheet 를 통해 카메라 접근 또는 포토 앨범 접근
- [x] 카메라 접근 권한 거절 시 Setting 으로 이동
- [x] 사진 선택 또는 촬영 시 UI 에 해당 이미지 보여주기 

---

### :pencil2: 학습 키워드

- UIImage & UIImageView
- UIImagePickerController
- delegate & protocol
- UIAlertController & UIAlertAction
- AVFoundation & AVCaptureDevice

---

### :pencil2: 고민과 해결

- `UIIamgePickerController.SourceType` 정보를 `.camera` 로 변경하였을 때 시뮬레이터에서 앱이 죽는 문제가 있었고 기기의 카메라 사용이 가능한 경우에만 카메라를 선택할 수 있는 옵션을 노출시켰습니다.

- 카메라 권한에 대한 정보를 설정하지 않아 앱이 죽는 문제가 있었고 Target-Info 메뉴에서 `Privacy - Camera Usage Description` 를 추가해 해결하였습니다.

- 카메라 접근 권한 거부 시 카메라가 정상 작동하지 않은 문제가 있었고 권한을 재요청하기 위해 팝업창을 만들어  사용자를 `Setting` 화면으로 이동하게끔  유도하였습니다.

---
